### PR TITLE
useFunnel 훅 구현

### DIFF
--- a/src/hooks/useFunnel/Funnel.tsx
+++ b/src/hooks/useFunnel/Funnel.tsx
@@ -1,0 +1,22 @@
+import { FunnelContext } from './context';
+import { FunnelContextType, FunnelData, FunnelStep } from './type';
+
+type FunnelComponentProps<T extends FunnelStep, D extends Record<string, unknown>> = {
+  children: React.ReactNode;
+  currentStep: T;
+  data: FunnelData<D>;
+};
+
+export const Funnel = <T extends FunnelStep, D extends Record<string, unknown>>({
+  children,
+  currentStep,
+  data,
+}: FunnelComponentProps<T, D>) => {
+  return (
+    <FunnelContext.Provider
+      value={{ currentStep, data } as FunnelContextType<string, Record<string, unknown>>}
+    >
+      {children}
+    </FunnelContext.Provider>
+  );
+};

--- a/src/hooks/useFunnel/Step.tsx
+++ b/src/hooks/useFunnel/Step.tsx
@@ -1,0 +1,13 @@
+import { useFunnelContext } from './context';
+import { FunnelStep } from './type';
+
+type StepProps<T extends FunnelStep> = {
+  children: React.ReactNode;
+  name: T;
+};
+
+export const Step = <T extends string>({ children, name }: StepProps<T>) => {
+  const { currentStep } = useFunnelContext();
+  if (name !== currentStep) return null;
+  return <>{children}</>;
+};

--- a/src/hooks/useFunnel/context.tsx
+++ b/src/hooks/useFunnel/context.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+import { FunnelContextType, FunnelStep } from './type';
+
+export const FunnelContext = createContext<FunnelContextType<
+  FunnelStep,
+  Record<string, unknown>
+> | null>(null);
+
+export const useFunnelContext = <T extends FunnelStep, D extends Record<string, unknown>>() => {
+  const context = useContext(FunnelContext) as FunnelContextType<T, D> | null;
+
+  if (!context) {
+    throw new Error('퍼널 Context는 Funnel Provider 내에서 사용할 수 있습니다.');
+  }
+  return context;
+};

--- a/src/hooks/useFunnel/index.tsx
+++ b/src/hooks/useFunnel/index.tsx
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Funnel } from './Funnel';
+import { Step } from './Step';
+import { FunnelData } from './type';
+
+export const useFunnel = <T extends readonly string[], D extends Record<string, unknown>>(
+  steps: T,
+  data: FunnelData<D>
+) => {
+  //현재 퍼널 단계
+  const [currentStep, setCurrentStep] = useState<T[number]>(steps[0]);
+
+  //웹 자체 뒤로가기 버튼 클릭 이벤트 발생 시 funnel 과 연동하는 로직
+  useEffect(() => {
+    if (!window.history.state) {
+      window.history.replaceState({ step: steps[0] }, '');
+    }
+
+    const handlePopState = (event: PopStateEvent) => {
+      const targetStep = event.state?.step;
+
+      if (targetStep && steps.includes(targetStep)) {
+        setCurrentStep(targetStep);
+      } else {
+        const currentIndex = steps.indexOf(currentStep);
+        if (currentIndex > 0) {
+          const previousStep = steps[currentIndex - 1];
+          setCurrentStep(previousStep);
+          window.history.replaceState({ step: previousStep }, '');
+        } else {
+          setCurrentStep(steps[0]);
+          window.history.replaceState({ step: steps[0] }, '');
+        }
+      }
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [currentStep]);
+
+  //다른 단계로 이동하는 onClick함수
+  const handleStep = useCallback(
+    (step: T[number]) => {
+      const currentIndex = steps.indexOf(currentStep);
+      const targetIndex = steps.indexOf(step);
+
+      if (!steps.includes(step)) return;
+      if (targetIndex > currentIndex) {
+        window.history.pushState({ step, timestamp: Date.now() }, '');
+      } else {
+        window.history.replaceState({ step }, '');
+      }
+      setCurrentStep(step);
+    },
+    [steps]
+  );
+
+  //퍼널 컴포넌트
+  const FunnelComponent = ({ children }: { children: React.ReactNode }) => {
+    return (
+      <Funnel currentStep={currentStep} data={data}>
+        {children}
+      </Funnel>
+    );
+  };
+
+  FunnelComponent.Steps = Step;
+
+  return { FunnelComponent, handleStep, currentStep };
+};

--- a/src/hooks/useFunnel/type.ts
+++ b/src/hooks/useFunnel/type.ts
@@ -1,0 +1,13 @@
+export type FunnelStep = string;
+
+export type StateAndSetter<T> = readonly [T, (value: T | ((prev: T) => T)) => void];
+
+export type FunnelData<T extends Record<string, unknown>> = {
+    [K in keyof T]: StateAndSetter<T[K]>;
+  };
+
+ 
+export type FunnelContextType<T extends FunnelStep, D extends Record<string, unknown>> = {
+  currentStep: T;
+  data: FunnelData<D>;
+};

--- a/src/pages/homepage/index.tsx
+++ b/src/pages/homepage/index.tsx
@@ -1,14 +1,31 @@
-import Spinner from '@/components/common/Spinner';
-import Sample from '@/components/sample';
-import { Suspense } from 'react';
+import { useState } from 'react';
+import { useFunnel } from '@/hooks/useFunnel';
 
 const HomePage = () => {
+  const [text, setText] = useState<string>('zz');
+  const [text1, setText1] = useState<string>('ss');
+
+  const STEPS = ['1', '2', '3', '4'] as const;
+
+  const funnelData = {
+    step1: [text, setText] as [string, typeof setText],
+    step2: [text1, setText1] as [string, typeof setText1],
+  };
+  const { FunnelComponent, handleStep, currentStep } = useFunnel(STEPS, funnelData);
+
   return (
-    <div style={{ height: '300px', overflowY: 'scroll' }}>
-      <Suspense fallback={<Spinner />}>
-        <Sample />
-      </Suspense>
-    </div>
+    <>
+      <button onClick={() => handleStep('1')}>1</button>
+      <button onClick={() => handleStep('2')}>2</button>
+      <button onClick={() => handleStep('3')}>3</button>
+      <button onClick={() => handleStep('4')}>4</button>
+      <FunnelComponent>
+        <FunnelComponent.Steps name="1">1단계</FunnelComponent.Steps>
+        <FunnelComponent.Steps name="2">2단계</FunnelComponent.Steps>
+        <FunnelComponent.Steps name="3">3단계</FunnelComponent.Steps>
+        <FunnelComponent.Steps name="4">4단계</FunnelComponent.Steps>
+      </FunnelComponent>
+    </>
   );
 };
 


### PR DESCRIPTION
# 🔢 이슈 번호

- OMF-44

## ⚙ 작업 사항

- [x] `useFunnel` 훅 구현
**useFunnel 이란?**
`선언적이고 명시적으로 퍼널 스텝을 관리하고, 퍼널에 대한 상태의 흐름을 명확하게 파악할 수 있도록 만든 퍼널 컨트롤러입니다.`
기존 페이지를 기반으로 라우팅 하는 단계적 로직을 하나의 페이지안에서 처리할 수 있게 해주는 방식으로 Context-Api를 활용해서 구현했습니다. 자세한 내용은 참고자료를 참고해주시면 됩니다!

**사용방법**
정의 하고자 하는 단계를 `string` 배열로 정의해주신 뒤, 공용으로 사용할 data를 `funnelData`로 정의해 useFunnel 컴포넌트 매개변수로 넘겨주세요, 그리고 나서 각 step에 맞는 페이지를 children으로 감싸주면 됩니다.
```tsx
const [text, setText] = useState<string>('');
  const [text1, setText1] = useState<string>('');

  const STEPS = ['1', '2', '3', '4'] as const;

  const funnelData = {
    step1: [text, setText] as [string, typeof setText],
    step2: [text1, setText1] as [string, typeof setText1],
  };
  const { FunnelComponent, handleStep, currentStep } = useFunnel(STEPS, funnelData);

  return (
    <>
      <button onClick={() => handleStep('1')}>1</button>
      <button onClick={() => handleStep('2')}>2</button>
      <button onClick={() => handleStep('3')}>3</button>
      <button onClick={() => handleStep('4')}>4</button>
      <FunnelComponent>
        <FunnelComponent.Steps name="1">1단계</FunnelComponent.Steps>
        <FunnelComponent.Steps name="2">2단계</FunnelComponent.Steps>
        <FunnelComponent.Steps name="3">3단계</FunnelComponent.Steps>
        <FunnelComponent.Steps name="4">4단계</FunnelComponent.Steps>
      </FunnelComponent>
    </>
  );
```

## 📃 참고자료

- [toss의 useFunnel 공식 문서] https://www.slash.page/ko/libraries/react/use-funnel/README.i18n
- [toss의 useFunnel 영상 설명] (https://www.youtube.com/watch?v=NwLWX2RNVcw&t=873s)

## 📷 스크린샷
