### PR TITLE
채점 결과 상세 페이지 구현

### DIFF
--- a/src/components/common/Card/ResultCard.tsx
+++ b/src/components/common/Card/ResultCard.tsx
@@ -2,23 +2,26 @@ import Body2 from '../Typography/Body2';
 import Title2 from '../Typography/Title2';
 import classNames from 'classnames';
 import $ from './resultcard.module.scss';
-import { ResultCardProps } from './CardType';
-import { scoreImages } from '@/constants/business.constants';
-import getScoreInfo from '@/hooks/getScoreInfo';
 
-const ResultCard = ({ score, variant, isHas }: ResultCardProps) => {
-  const scoreInfo = getScoreInfo(score);
-
+export interface ResultCardProps {
+  score: number;
+  image: string;
+  title: string;
+  description: string;
+  variant: 'score' | 'animate';
+  isHas?: boolean;
+}
+const ResultCard = ({ score, image, title, description, variant, isHas }: ResultCardProps) => {
   return (
     <div
       className={classNames($.resultcard, {
         [$.animate]: variant === 'animate',
       })}
     >
-      {variant === 'score' && <div className={classNames($.score)}>{score}</div>}
+      {variant === 'score' && <div className={classNames($.score)}>{score}점!</div>}
       <img
-        src={scoreImages[scoreInfo.imageKey]}
-        alt={`Score ${scoreInfo.description}`}
+        src={image}
+        alt={'점수 이미지'}
         className={classNames($.image, {
           [$.animate]: variant === 'animate',
           [$.blur]: variant === 'animate' && !isHas,
@@ -29,8 +32,8 @@ const ResultCard = ({ score, variant, isHas }: ResultCardProps) => {
           [$.blur]: variant === 'animate' && !isHas,
         })}
       >
-        <Title2>{scoreInfo.title}</Title2>
-        {variant === 'score' && <Body2>{scoreInfo.description}</Body2>}
+        <Title2>{title}</Title2>
+        {variant === 'score' && <Body2>{description}</Body2>}
       </div>
     </div>
   );

--- a/src/components/common/Card/resultcard.module.scss
+++ b/src/components/common/Card/resultcard.module.scss
@@ -1,46 +1,45 @@
 @use '@/colors' as *;
 @use '@/styles/mixin.scss' as *;
 
-.resultcard { 
-    @include center;
-    @include block-padding;
-    flex-direction: column; 
-    text-align: center;
-    height: 454px;
-    padding: 48px 24px;
-    gap: 24px;
-    border-radius: 16px;
-    box-shadow: inset 0 0 1px 0 #AEECFF, 12px 12px 28px 0 rgba(0, 0, 0, 0.05);
-    flex-shrink: 0;
-    &.animate {
-      @include size(242px, 227px); 
-      box-shadow:  12px 12px 28px 0 rgba(0, 0, 0, 0.05);
-    } 
-    &.blur {
-       @include blur;
-    }
-   
-}   
+.resultcard {
+  @include center;
+  @include block-padding;
+  flex-direction: column;
+  text-align: center;
+  height: 454px;
+  padding: 48px 24px;
+  gap: 24px;
+  border-radius: 16px;
+  box-shadow: inset 0 0 1px 0 #aeecff, 12px 12px 28px 0 rgba(0, 0, 0, 0.05);
+  background-color: white;
+  flex-shrink: 0;
+  &.animate {
+    @include size(242px, 227px);
+    box-shadow: 12px 12px 28px 0 rgba(0, 0, 0, 0.05);
+  }
+  &.blur {
+    @include blur;
+  }
+}
 
-.image { 
-    &.animate {
-        @include size(80px, 80px);
-    }
-    &.blur {
-        @include blur;
-    }
+.image {
+  &.animate {
+    @include size(80px, 80px);
+  }
+  &.blur {
+    @include blur;
+  }
 }
 
 .score {
-    font-size: 48px;
-    color: $main300;
-    font-weight: bold;
-    line-height: 56px;
+  font-size: 48px;
+  color: $main300;
+  font-weight: bold;
+  line-height: 56px;
 }
 
-.content { 
-    &.blur {
-        @include blur;
-    }
+.content {
+  &.blur {
+    @include blur;
+  }
 }
-

--- a/src/components/domain/CheckScore/AnimateCardSample/animateCardSample.module.scss
+++ b/src/components/domain/CheckScore/AnimateCardSample/animateCardSample.module.scss
@@ -1,7 +1,9 @@
 .sample {
-  //그림자 경계가 부자연스러워 padding 추가함
-  padding: 24px 0;
+  position: relative;
+  left: -20px;
+  width: calc(100% + 40px);
   display: flex;
+  padding: 24px 0;
   gap: 24px;
   white-space: nowrap;
   overflow: scroll;

--- a/src/components/domain/CheckScore/AnimateCardSample/animateCardSample.module.scss
+++ b/src/components/domain/CheckScore/AnimateCardSample/animateCardSample.module.scss
@@ -1,9 +1,11 @@
 .sample {
-    display: flex; 
-    gap: 24px;  
-    white-space: nowrap;
-    overflow:scroll;
-    &::-webkit-scrollbar { 
-        display: none;
-    }
+  //그림자 경계가 부자연스러워 padding 추가함
+  padding: 24px 0;
+  display: flex;
+  gap: 24px;
+  white-space: nowrap;
+  overflow: scroll;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }

--- a/src/components/domain/CheckScore/AnimateCardSample/index.tsx
+++ b/src/components/domain/CheckScore/AnimateCardSample/index.tsx
@@ -1,12 +1,20 @@
 import { useEffect, useRef, useState } from 'react';
 import $ from './animateCardSample.module.scss';
 import ResultCard from '@/components/common/Card/ResultCard';
+import { scoreImages, scoreTable } from '@/constants/business.constants';
 
 export default function AnimateCardSample() {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const scrollIntervalRef = useRef<number>();
   const scrollSpeed = 15;
   const [isScrollingRight, setIsScrollingRight] = useState(true);
+
+  const cardData = scoreTable.map((data) => ({
+    score: parseInt(data.imageKey.slice(1)),
+    image: scoreImages[data.imageKey as keyof typeof scoreImages],
+    title: data.title,
+    description: data.description,
+  }));
 
   useEffect(() => {
     const scrollContainer = scrollRef.current;
@@ -54,11 +62,17 @@ export default function AnimateCardSample() {
 
   return (
     <div className={$.sample} ref={scrollRef}>
-      <ResultCard score={20} variant='animate' isHas={true} />
-      <ResultCard score={40} variant='animate' isHas={false} />
-      <ResultCard score={60} variant='animate' isHas={false} />
-      <ResultCard score={80} variant='animate' isHas={false} />
-      <ResultCard score={100} variant='animate' isHas={false} />
+      {cardData.map((card) => (
+        <ResultCard
+          key={card.score}
+          score={card.score}
+          variant="animate"
+          isHas={false}
+          image={card.image}
+          title={card.title}
+          description={card.description}
+        />
+      ))}
     </div>
   );
 }

--- a/src/container/check-score/checkScoreDetail.module.scss
+++ b/src/container/check-score/checkScoreDetail.module.scss
@@ -17,14 +17,15 @@
   flex-direction: column;
   text-align: center;
   margin-bottom: 56px;
-  h2 {
-    color: $Gray500;
-    margin-bottom: 40px;
-  }
   p {
     color: $Gray300;
     margin-top: 24px;
   }
+}
+
+.Title {
+  color: $Gray500;
+  margin-bottom: 40px;
 }
 
 .AnimateCard {

--- a/src/container/check-score/checkScoreDetail.module.scss
+++ b/src/container/check-score/checkScoreDetail.module.scss
@@ -1,0 +1,38 @@
+@use '@/colors' as *;
+@use '@/styles/mixin.scss' as *;
+
+.Wrapper {
+  padding: 0 20px;
+  height: 100%;
+}
+
+.Container {
+  height: calc(100% - 48px);
+  padding-top: 24px;
+  padding-bottom: 83px;
+}
+
+.ItemContainer {
+  @include center;
+  flex-direction: column;
+  text-align: center;
+  margin-bottom: 56px;
+  h2 {
+    color: $Gray500;
+    margin-bottom: 40px;
+  }
+  p {
+    color: $Gray300;
+    margin-top: 24px;
+  }
+}
+
+.AnimateCard {
+  margin-bottom: 24px;
+}
+
+.ButtonContainer {
+  @include center;
+  flex-direction: column;
+  gap: 12px;
+}

--- a/src/container/check-score/detail.tsx
+++ b/src/container/check-score/detail.tsx
@@ -9,6 +9,7 @@ import AnimateCardSample from '@/components/domain/CheckScore/AnimateCardSample'
 import Button from '@/components/common/Button';
 import KakaoLogo from '@/assets/svg/KakaoLogo.svg';
 import { ResultCardProps } from '@/components/common/Card/ResultCard';
+import KakaoShareButton from '@/components/common/KakaoShareButton';
 
 interface CheckScoreDetailProps extends ResultCardProps {
   nickname: string;
@@ -28,8 +29,6 @@ export default function CheckScoreDetailLayout({
   const onBack = () => {
     navigate(-1);
   };
-
-  const handleShare = () => {};
 
   const handleNewTest = () => {
     navigate('/test');
@@ -61,9 +60,7 @@ export default function CheckScoreDetailLayout({
         </div>
 
         <div className={classNames($.ButtonContainer)}>
-          <Button variant="kakaoLogin" onClick={handleShare} icon={KakaoLogo}>
-            테스트 공유하기
-          </Button>
+          <KakaoShareButton />
           <Button variant="secondary" onClick={handleNewTest}>
             새로운 테스트 시작하기
           </Button>

--- a/src/container/check-score/detail.tsx
+++ b/src/container/check-score/detail.tsx
@@ -40,10 +40,12 @@ export default function CheckScoreDetailLayout({
       <AppBar leftRole="back" onClickLeftButton={onBack} />
       <div className={classNames($.Container)}>
         <div className={classNames($.ItemContainer)}>
-          <Title2>
-            {nickname}가
-            <br /> 채점한 내 점수는?
-          </Title2>
+          <div className={classNames($.Title)}>
+            <Title2>
+              {nickname}가
+              <br /> 채점한 내 점수는?
+            </Title2>
+          </div>
           <ResultCard
             score={score}
             image={image}

--- a/src/container/check-score/detail.tsx
+++ b/src/container/check-score/detail.tsx
@@ -1,12 +1,72 @@
-import { useParams } from 'react-router-dom';
+import $ from './checkScoreDetail.module.scss';
+import classNames from 'classnames';
+import AppBar from '@/components/common/AppBar';
+import { useNavigate } from 'react-router-dom';
+import { Body1, Title2 } from '@/components/common/Typography';
+import GradingCard from '@/components/common/Card/GradingCard';
+import ResultCard from '@/components/common/Card/ResultCard';
+import AnimateCardSample from '@/components/domain/CheckScore/AnimateCardSample';
+import Button from '@/components/common/Button';
+import KakaoLogo from '@/assets/svg/KakaoLogo.svg';
+import { ResultCardProps } from '@/components/common/Card/ResultCard';
 
-export default function CheckScoreDetail() {
-  const { id } = useParams();
+interface CheckScoreDetailProps extends ResultCardProps {
+  nickname: string;
+  explanation: string;
+}
+
+export default function CheckScoreDetailLayout({
+  score,
+  nickname,
+  image,
+  title,
+  description,
+  explanation,
+}: CheckScoreDetailProps) {
+  const navigate = useNavigate();
+
+  const onBack = () => {
+    navigate(-1);
+  };
+
+  const handleShare = () => {};
+
+  const handleNewTest = () => {
+    navigate('/test');
+  };
 
   return (
-    <div>
-      <h1>점수 상세보기 </h1>
-      <h1>점수id: {id}</h1>
+    <div className={classNames($.Wrapper)}>
+      <AppBar leftRole="back" onClickLeftButton={onBack} />
+      <div className={classNames($.Container)}>
+        <div className={classNames($.ItemContainer)}>
+          <Title2>
+            {nickname}가
+            <br /> 채점한 내 점수는?
+          </Title2>
+          <ResultCard
+            score={score}
+            image={image}
+            title={title}
+            description={description}
+            variant="score"
+          />
+          <Body1>{explanation}</Body1>
+        </div>
+        <div className={classNames($.AnimateCard)}>
+          <Title2>더 많은 카드를 수집해보세요!</Title2>
+          <AnimateCardSample />
+        </div>
+
+        <div className={classNames($.ButtonContainer)}>
+          <Button variant="kakaoLogin" onClick={handleShare} icon={KakaoLogo}>
+            테스트 공유하기
+          </Button>
+          <Button variant="secondary" onClick={handleNewTest}>
+            새로운 테스트 시작하기
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/check-score/detail.tsx
+++ b/src/pages/check-score/detail.tsx
@@ -1,12 +1,75 @@
-import { useParams } from 'react-router-dom';
+import CheckScoreDetailLayout from '@/container/check-score/detail';
+import { P100, P20, P40, P60, P80, P90 } from '@components/common/TossFace';
+
+const scoreMockData = [
+  {
+    imageKey: P20,
+    nickname: '엄망',
+    title: '말하는 감자',
+    description: '저는 말하는 감자라구요. 아시겠어요?',
+    explanation:
+      '사실 당신은 인간이 된 꿈을 꾸고 있는 감자인 것입니다. 감자가 사람이 되기 위해서는 쑥과 마늘을 먹어야 하지만, 당신은 그러지 않았군요.',
+    score: 20,
+  },
+  {
+    imageKey: P40,
+    nickname: '어무니',
+    title: '효자 맛보기 스푼',
+    description: '효도를 이렇게 콕 찍어서 뇸!',
+    explanation:
+      '효도는 한 스푼씩, 조금씩 실천하는 것부터 시작입니다. 지금부터라도 시작해보는 건 어떨까요?',
+    score: 40,
+  },
+  {
+    imageKey: P60,
+    nickname: '아부지',
+    title: '효자 호소인',
+    description: '어어색할거같진 않고 분명히어색할거같아요',
+    explanation:
+      '어색하지만 그래도 노력하는 모습이 보이네요. 조금 더 자연스러워질 수 있도록 해보아요.',
+    score: 60,
+  },
+  {
+    imageKey: P80,
+    nickname: '아빵',
+    title: '말하는 감자',
+    description: '저는 말하는 감자라구요. 아시겠어요?',
+    explanation: '무럭무럭 자라나는 새싹처럼, 당신의 효심도 쑥쑥 자라나고 있습니다!',
+    score: 80,
+  },
+  {
+    imageKey: P90,
+    nickname: '엄마아',
+    title: '홍진효',
+    description: '홍진효',
+    explanation: '거의 다 왔어요! 조금만 더 노력하면 완벽한 효자/효녀가 될 수 있을 거예요.',
+    score: 90,
+  },
+  {
+    imageKey: P100,
+    nickname: '아빠앙',
+    title: '인간 코지마',
+    description: '사랑하니까 바디프렌드 (둘 다 광고 아님)',
+    explanation: '당신은 이미 완벽한 효자/효녀입니다! 이대로만 계속 해주세요.',
+    score: 100,
+  },
+];
 
 export default function CheckScoreDetail() {
-  const { id } = useParams();
+  //임시
+  const data = scoreMockData[0];
 
   return (
     <div>
-      <h1>점수 상세보기 </h1>
-      <h1>점수id: {id}</h1>
+      <CheckScoreDetailLayout
+        nickname={data.nickname}
+        image={data.imageKey}
+        title={data.title}
+        description={data.description}
+        explanation={data.explanation}
+        variant="score"
+        score={data.score}
+      />
     </div>
   );
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -25,6 +25,8 @@ export const routes = [
           { path: ':id', element: <CheckScoreDetail /> },
         ],
       },
+      // 임시
+      { path: 'detail', element: <CheckScoreDetail /> },
       { path: 'guide', element: <Guide /> },
       { path: 'login', element: <Login /> },
       { path: 'kakao/callback', element: <Redirection /> },


### PR DESCRIPTION
# 🔢 이슈 번호

- OMF-56

## ⚙ 작업 사항

- ResultCard에 필요한 내용을 모두 서버에서 받아오기 위해 ResultCard props 수정
- ResultCard props 수정에 따른 AnimateCard 수정
- 채점 결과 상세 페이지 구현


## 📷 스크린샷
<img width="200" alt="스크린샷 2024-11-29 01 34 22" src="https://github.com/user-attachments/assets/da98203a-3b58-4143-b384-a778e3f7eaee">
<img width="200" alt="스크린샷 2024-11-29 01 34 32" src="https://github.com/user-attachments/assets/e8209f32-4ef4-4a39-85a2-47a124b74cd9">

