### PR TITLE
모바일 폰트 cross origin 문제 해결

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -23,12 +23,12 @@ input {
   margin: 0;
   padding: 0;
   border: 0;
-  font-family: 'Pretendard';
+  font-family: 'Pretendard', '-apple-system', 'BlinkMacSystemFont', 'system-ui', 'Roboto', 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', sans-serif;
 }
 
 input,
 ::placeholder {
-  font-family: 'Pretendard';
+  font-family: 'Pretendard', '-apple-system', 'BlinkMacSystemFont', 'system-ui', 'Roboto', 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', sans-serif;
 }
 
 a {


### PR DESCRIPTION
# 🔢 이슈 번호

- OMF-88

## ⚙ 작업 사항

- 모바일 환경에서 프리텐다드 폰트가 숫자와 기호에 적용되지 않는 에러를 해결하기 위해 대체폰트를 추가함. 

## 📃 참고자료

- https://interested-in.tistory.com/31#google_vignette
