### PR TITLE
답변 제출, 채점 관련 api 연동

### DIFF
--- a/src/apis/api/auth.ts
+++ b/src/apis/api/auth.ts
@@ -13,3 +13,13 @@ export const getUserInfo = async() => {
 
     return data;
 }
+
+// 채점 페이지에서 카카오이름, 애칭 정보 가져오기
+export const getUserNames = async (quizid: number) => {
+    const { data } = await instance.get(`/api/user`, {
+        params: {
+            quizid: quizid
+        }
+    });
+    return data;
+};

--- a/src/apis/api/test.ts
+++ b/src/apis/api/test.ts
@@ -1,7 +1,8 @@
 import { instance } from '../instance'; 
 import {
   GradingPayloadType,
-  QuestionResponseData,  
+  QuestionResponseData,
+  SubmitAnswerPayload,  
 } from './test.types'; 
  
 
@@ -19,10 +20,19 @@ export const getQuestion = async (nickname: string, familyType: string): Promise
   return data.data;
 };
 
+
 // 답변 제출 api
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const submitAnswer = async (payload: any) => {
-  const {data} = await instance.post('api/submit', payload, {
+export const submitAnswer = async (payload: SubmitAnswerPayload) => {
+  const { data } = await instance.post('api/submit', payload);
+  return data;
+};
+
+
+// 이미지 업로드 api
+export const uploadImage = async (image: File) => {
+  const formData = new FormData();
+  formData.append('image', image);
+  const { data } = await instance.patch('api/upload', formData, {
     headers: {
       'Content-Type': 'multipart/form-data'
     }
@@ -30,6 +40,7 @@ export const submitAnswer = async (payload: any) => {
   return data;
 };
 
+ // 답변 조회
 export const getAnswer = async(quizid: number): Promise<QuestionResponseData[]> => {
   const {data} = await instance.get('api/answer', {
     params: {quizid}
@@ -37,7 +48,7 @@ export const getAnswer = async(quizid: number): Promise<QuestionResponseData[]> 
   return data.data.data;
 } 
 
- 
+ // 채점하기
 export const submitGrade = async(payload: GradingPayloadType) => {
   const {data} = await instance.post('api/score', payload);
 

--- a/src/apis/api/test.ts
+++ b/src/apis/api/test.ts
@@ -1,8 +1,10 @@
 import { instance } from '../instance'; 
+import { ApiResponseFormat } from './api.types';
 import {
   GradingPayloadType,
   QuestionResponseData,
-  SubmitAnswerPayload,  
+  SubmitAnswerPayload,
+  AnswerResponseData  
 } from './test.types'; 
  
 
@@ -41,11 +43,11 @@ export const uploadImage = async (image: File) => {
 };
 
  // 답변 조회
-export const getAnswer = async(quizid: number): Promise<QuestionResponseData[]> => {
+ export const getAnswer = async(quizid: number): Promise<ApiResponseFormat<AnswerResponseData>> => {
   const {data} = await instance.get('api/answer', {
     params: {quizid}
   }); 
-  return data.data.data;
+  return data;
 } 
 
  // 채점하기

--- a/src/apis/api/test.types.ts
+++ b/src/apis/api/test.types.ts
@@ -19,9 +19,10 @@ export interface QuestionResponseData {
 }
 
 // 답변 제출 타입
-export interface SubmitAnswerData extends FormData{ 
+export interface SubmitAnswerPayload {
   name: string;
   answer: (string | number)[];
+  image?: string; 
 }
 
 export interface SubmitAnswerResponse {

--- a/src/apis/api/test.types.ts
+++ b/src/apis/api/test.types.ts
@@ -25,6 +25,13 @@ export interface SubmitAnswerPayload {
   image?: string; 
 }
 
+
+// 자식 답변 호출 타입
+export interface AnswerResponseData {
+  image?: string;
+  data: QuestionResponseData[];
+}
+
 export interface SubmitAnswerResponse {
   data: {
     quizid: number;

--- a/src/apis/queries/answer.ts
+++ b/src/apis/queries/answer.ts
@@ -20,26 +20,35 @@ export const useUploadImageMutation = () => {
     }
   });
 };
- 
-//자식 답변 조회 
+
+//답변 조회
 export const useGetChildAnswer = (quizid: number) => {
   const { data } = useSuspenseQuery({
     queryKey: ['answer', quizid],
     queryFn: () => getAnswer(quizid),
     staleTime: 5 * 60 * 1000
   });
-  return data;
+  
+  return {
+    answers: data.data.data,
+    imageUrl: data.data.image
+  };
 };
 
 //부모 채점 
-export const useSubmitGrading = () => {
+export const useSubmitGrading = (
+  onSuccess?: () => void,
+  onError?: () => void
+) => {
   return useMutation({
     mutationFn: submitGrade,
     onSuccess: (data) => {
       console.log('채점 성공');
+      onSuccess?.();
     },
     onError: (error) => {
       console.log('채점 실패');
+      onError?.();
     }
   })
 }

--- a/src/apis/queries/answer.ts
+++ b/src/apis/queries/answer.ts
@@ -1,5 +1,5 @@
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
-import { getAnswer, submitAnswer, submitGrade } from '../api/test';
+import { getAnswer, submitAnswer, submitGrade, uploadImage } from '../api/test';
 import { SubmitAnswerResponse } from '../api/test.types';
 
 // 자식 답변 제출
@@ -11,7 +11,15 @@ export const useSubmitAnswerMutation = (onSuccess: (data: SubmitAnswerResponse) 
   });
  };
 
-
+// 이미지 업로드 
+export const useUploadImageMutation = () => {
+  return useMutation({
+    mutationFn: uploadImage,
+    onError: (error) => {
+      console.log('이미지 업로드 실패');
+    }
+  });
+};
  
 //자식 답변 조회 
 export const useGetChildAnswer = (quizid: number) => {

--- a/src/apis/queries/user.ts
+++ b/src/apis/queries/user.ts
@@ -1,7 +1,7 @@
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { setAuthToken } from '@/apis/instance';
-import { getUserInfo, kakaoLogin } from '../api/auth';
+import { getUserInfo, getUserNames, kakaoLogin } from '../api/auth';
 
 
 export const useKakaoLoginQuery = () => {
@@ -24,3 +24,13 @@ export const useGetUserInfo = () => {
         select: (response) => response.data
     })
 }
+
+export const useGetUserNames = (quizid: number) => {
+    const { data } = useSuspenseQuery({
+      queryKey: ['userNames', quizid],
+      queryFn: () => getUserNames(quizid),
+      staleTime: 5 * 60 * 1000
+    });
+    return data.data;
+  };
+

--- a/src/components/domain/grading/buttonLayout/index.tsx
+++ b/src/components/domain/grading/buttonLayout/index.tsx
@@ -6,7 +6,7 @@ import KakaoShareButton from '@/components/common/KakaoShareButton';
 export default function ButtonLayout() {
   const navigate = useNavigate();
   const onClickTestButton = () => {
-    navigate('/splash');
+    navigate('/login');
   };
   return (
     <div className={$.buttonLayout}>

--- a/src/container/grading/check/index.tsx
+++ b/src/container/grading/check/index.tsx
@@ -25,6 +25,7 @@ import { useParams } from 'react-router-dom';
 type CheckLayoutProps = {
   handleStep: (step: string) => void;
   setHasImage: Dispatch<SetStateAction<boolean>>;
+  setImageUrl: Dispatch<SetStateAction<string>>;
 };
 
 export type AnswerCardType = {
@@ -47,11 +48,18 @@ const emoje = {
   think: Think,
 };
 
-export default function CheckLayout({ handleStep, setHasImage }: CheckLayoutProps) {
+export default function CheckLayout({ handleStep, setHasImage, setImageUrl}: CheckLayoutProps) {
   const [answerList, setAnswerList] = useState<(boolean | null)[]>(Array(10).fill(null));
   const {quizid} = useParams();
 
-  const answers = useGetChildAnswer(Number(quizid));
+  const { answers, imageUrl } = useGetChildAnswer(Number(quizid));
+  useEffect(() => {
+    setHasImage(!!imageUrl);
+    if (imageUrl) {
+      setImageUrl(imageUrl);
+      console.log(imageUrl);
+    }
+  }, [imageUrl, setHasImage, setImageUrl]);
 
   const mainRef = useRef<HTMLDivElement | null>(null);
 
@@ -64,8 +72,11 @@ export default function CheckLayout({ handleStep, setHasImage }: CheckLayoutProp
     console.log('채점 실패');
   };
 
-  const { mutate: submitGrade } = useSubmitGrading();
-
+  const { mutate: submitGrade } = useSubmitGrading(
+    onSuccessSubmitGrade,
+    onErrorSubmitGrade
+  );
+  
   const onClickLeftButton = () => {
     handleStep('가이드');
   };

--- a/src/container/grading/complete/HasImage/hasImage.module.scss
+++ b/src/container/grading/complete/HasImage/hasImage.module.scss
@@ -2,7 +2,7 @@
 @use '@/styles/mixin.scss' as *;
 .Wrapper {
     @include center();
-    height: 100%;
+    height: 100dvh;
 }
 
 .layout { 

--- a/src/container/grading/complete/HasImage/index.tsx
+++ b/src/container/grading/complete/HasImage/index.tsx
@@ -5,12 +5,18 @@ import { Body1, Title2 } from '@/components/common/Typography';
 import { Angel } from '@/components/common/TossFace';
 import sample from '@/assets/image/splash1.png';
 import ButtonLayout from '@/components/domain/grading/buttonLayout';
+import { useParams } from 'react-router-dom';
+import { useGetUserNames } from '@/apis/queries/user';
 
 type HasImageProps = {
   handleStep: (step: string) => void;
+  imageUrl?: string;
 };
 
-export default function HasImage({ handleStep }: HasImageProps) {
+export default function HasImage({ handleStep, imageUrl }: HasImageProps) {
+  const {quizid} = useParams();
+  const names = useGetUserNames(Number(quizid));
+  
   const [step, setStep] = useState<number>(0);
 
   useEffect(() => {
@@ -28,7 +34,7 @@ export default function HasImage({ handleStep }: HasImageProps) {
         {step === 1 && (
           <div className={$.step2}>
             <Title2>
-              닉네임이 수줍게 <br /> 간직하고 있는 나의 사진입니다.
+              {names.kakao_nickname}이 수줍게 <br /> 간직하고 있는 나의 사진입니다.
             </Title2>
             <div className={$.text}>
               <Body1>
@@ -36,7 +42,7 @@ export default function HasImage({ handleStep }: HasImageProps) {
               </Body1>
             </div>
             <div className={$.image}>
-              <img src={sample} />
+            <img src={imageUrl || sample} alt="자식 업로드 이미지" /> 
             </div>
             <ButtonLayout />
           </div>

--- a/src/container/grading/complete/NoImage/noImage.module.scss
+++ b/src/container/grading/complete/NoImage/noImage.module.scss
@@ -6,6 +6,7 @@
 }
 
 .layout { 
+    margin-top: 80.44px;
     text-align: center;
     padding: 0 20px;
     flex-grow: 1;

--- a/src/container/grading/guide/index.tsx
+++ b/src/container/grading/guide/index.tsx
@@ -5,13 +5,17 @@ import $ from './guide.module.scss';
 import { Body2 } from '@/components/common/Typography';
 import Button from '@/components/common/Button';
 import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useGetUserNames } from '@/apis/queries/user';
 
 type GuideLayoutProps = {
   handleStep: (step: string) => void;
-  nickname: string | null;
 };
 
-export default function GuideLayout({ handleStep, nickname }: GuideLayoutProps) {
+export default function GuideLayout({ handleStep }: GuideLayoutProps) {
+  const {quizid} = useParams();
+  const names = useGetUserNames(Number(quizid));
+
   const [sample, setSample] = useState<(boolean | null)[]>([null]);
   const onClickLeftButton = () => {
     handleStep('메인');
@@ -25,7 +29,7 @@ export default function GuideLayout({ handleStep, nickname }: GuideLayoutProps) 
     <div className={$.layout}>
       <AppBar leftRole="back" onClickLeftButton={onClickLeftButton} className={$.appBar} />
       <GradingCard
-        title={`아래는 ${nickname}이가
+        title={`아래는 ${names.kakao_nickname}이가
          나에 대해 답한 내용입니다.`}
         cardImage={Call}
         cardNumber="연습문제"

--- a/src/container/grading/guide/index.tsx
+++ b/src/container/grading/guide/index.tsx
@@ -29,7 +29,7 @@ export default function GuideLayout({ handleStep }: GuideLayoutProps) {
     <div className={$.layout}>
       <AppBar leftRole="back" onClickLeftButton={onClickLeftButton} className={$.appBar} />
       <GradingCard
-        title={`아래는 ${names.kakao_nickname}이가
+        title={`아래는 ${names.kakao_nickname}이
          나에 대해 답한 내용입니다.`}
         cardImage={Call}
         cardNumber="연습문제"

--- a/src/container/grading/main/index.tsx
+++ b/src/container/grading/main/index.tsx
@@ -27,12 +27,12 @@ export default function MainLayout({ handleStep }: MainLayoutProps) {
             <Caption1>가정의 달 이벤트</Caption1>
           </BlueTitleText>
           <Title1>
-            {names.kakao_nickname}이가 직접 푼
+            {names.kakao_nickname}이 직접 푼
             <br />
             {names.nickname} 10문 10답
           </Title1>
           <Body2>
-          {names.kakao_nickname}이가 나에 대한 간단한 퀴즈 10개를 풀었어요.
+          {names.kakao_nickname}이 나에 대한 간단한 퀴즈 10개를 풀었어요.
             <br />
             정답은 오로지 나만 알고 있답니다!
             <br />

--- a/src/container/grading/main/index.tsx
+++ b/src/container/grading/main/index.tsx
@@ -4,13 +4,17 @@ import BlueTitleText from '@/components/common/Item/BlueTitleText';
 import { Body2, Caption1, Title1 } from '@/components/common/Typography';
 import Button from '@/components/common/Button';
 import BackgroundSVG from '@/components/common/Item/BackgroundSVG';
+import { useParams } from 'react-router-dom';
+import { useGetUserNames } from '@/apis/queries/user';
 
 type MainLayoutProps = {
   handleStep: (step: string) => void;
-  nickname: string | null;
 };
 
-export default function MainLayout({ handleStep, nickname }: MainLayoutProps) {
+export default function MainLayout({ handleStep }: MainLayoutProps) {
+  const {quizid} = useParams();
+  const names = useGetUserNames(Number(quizid));
+
   const onClickNextStep = () => {
     handleStep('가이드');
   };
@@ -23,12 +27,12 @@ export default function MainLayout({ handleStep, nickname }: MainLayoutProps) {
             <Caption1>가정의 달 이벤트</Caption1>
           </BlueTitleText>
           <Title1>
-            {nickname}이가 직접 푼
+            {names.kakao_nickname}이가 직접 푼
             <br />
-            애칭 10문 10답
+            {names.nickname} 10문 10답
           </Title1>
           <Body2>
-            {nickname}이가 나에 대한 간단한 퀴즈 10개를 풀었어요.
+          {names.kakao_nickname}이가 나에 대한 간단한 퀴즈 10개를 풀었어요.
             <br />
             정답은 오로지 나만 알고 있답니다!
             <br />

--- a/src/container/test/question/index.tsx
+++ b/src/container/test/question/index.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/common/TossFace';
 import { useSubmitAnswerMutation } from '@/apis/queries/answer';
 import { SubmitAnswerResponse } from '@/apis/api/test.types';
+import { uploadImage } from '@/apis/api/test';
 
 interface QuestionLayoutProps {
   handleStep: (step: string) => void;
@@ -93,12 +94,17 @@ function QuestionLayout({ handleStep, name, familyType, setQuizid }: QuestionLay
   };
 
   //답안 제출 버튼
-  const onSubmitAnswer = () => {
-    const formData = new FormData();
-    formData.append('image', selectedImage as Blob);
-    formData.append('name', name);
-    formData.append('answer', result as unknown as Blob);
-    submitAnswer(formData);
+  const onSubmitAnswer = async () => {
+    let image;
+    if (selectedImage) {
+      const imageResponse = await uploadImage(selectedImage);
+      image = imageResponse.data;
+    }
+      submitAnswer({
+      name,
+      answer: result,
+      image 
+    });
   };
 
   //답 입력 버튼

--- a/src/pages/grading/index.tsx
+++ b/src/pages/grading/index.tsx
@@ -11,6 +11,7 @@ export default function Grading() {
   const step = ['메인', '가이드', '채점', '완료'];
   const { FunnelComponent: Funnel, handleStep } = useFunnel(step, {});
   const [hasImage, setHasImage] = useState<boolean>(false);
+  const [imageUrl, setImageUrl] = useState<string>('');
 
   return (
     <Funnel>
@@ -26,11 +27,21 @@ export default function Grading() {
       </Funnel.Steps>
       <Funnel.Steps name="채점">
         <Suspense fallback={<Spinner />}>
-          <CheckLayout handleStep={handleStep} setHasImage={setHasImage} />
+          <CheckLayout
+            handleStep={handleStep}
+            setHasImage={setHasImage}
+            setImageUrl={setImageUrl}
+          />
         </Suspense>
       </Funnel.Steps>
       <Funnel.Steps name="완료">
-        {hasImage ? <HasImage handleStep={handleStep} /> : <NoImage handleStep={handleStep} />}
+        <Suspense fallback={<Spinner />}>
+          {hasImage ? (
+            <HasImage handleStep={handleStep} imageUrl={imageUrl} />
+          ) : (
+            <NoImage handleStep={handleStep} />
+          )}
+        </Suspense>
       </Funnel.Steps>
     </Funnel>
   );

--- a/src/pages/grading/index.tsx
+++ b/src/pages/grading/index.tsx
@@ -10,7 +10,6 @@ import { useSearchParams } from 'react-router-dom';
 
 export default function Grading() {
   const [searchParams] = useSearchParams();
-  const userId = searchParams.get('userId');
   const nickname = searchParams.get('nickname');
 
   const step = ['메인', '가이드', '채점', '완료'];
@@ -21,10 +20,18 @@ export default function Grading() {
   return (
     <Funnel>
       <Funnel.Steps name="메인">
-        <MainLayout handleStep={handleStep} nickname={nickname} />
+      <Suspense fallback={<Spinner />}>
+
+        <MainLayout handleStep={handleStep} />
+        </Suspense>
+
       </Funnel.Steps>
       <Funnel.Steps name="가이드">
-        <GuideLayout handleStep={handleStep} nickname={nickname!} />
+      <Suspense fallback={<Spinner />}>
+
+        <GuideLayout handleStep={handleStep} />
+        </Suspense>
+
       </Funnel.Steps>
       <Funnel.Steps name="채점">
         <Suspense fallback={<Spinner />}>

--- a/src/pages/grading/index.tsx
+++ b/src/pages/grading/index.tsx
@@ -6,32 +6,23 @@ import GuideLayout from '@/container/grading/guide';
 import MainLayout from '@/container/grading/main';
 import { useFunnel } from '@/hooks/useFunnel';
 import { Suspense, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
 
 export default function Grading() {
-  const [searchParams] = useSearchParams();
-  const nickname = searchParams.get('nickname');
-
   const step = ['메인', '가이드', '채점', '완료'];
-
   const { FunnelComponent: Funnel, handleStep } = useFunnel(step, {});
   const [hasImage, setHasImage] = useState<boolean>(false);
 
   return (
     <Funnel>
       <Funnel.Steps name="메인">
-      <Suspense fallback={<Spinner />}>
-
-        <MainLayout handleStep={handleStep} />
+        <Suspense fallback={<Spinner />}>
+          <MainLayout handleStep={handleStep} />
         </Suspense>
-
       </Funnel.Steps>
       <Funnel.Steps name="가이드">
-      <Suspense fallback={<Spinner />}>
-
-        <GuideLayout handleStep={handleStep} />
+        <Suspense fallback={<Spinner />}>
+          <GuideLayout handleStep={handleStep} />
         </Suspense>
-
       </Funnel.Steps>
       <Funnel.Steps name="채점">
         <Suspense fallback={<Spinner />}>

--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -33,14 +33,17 @@ function Test() {
       </Funnel.Steps>
       <Funnel.Steps name="질문">
         <Suspense fallback={<Spinner />}>
-          <QuestionLayout handleStep={handleStep} name={name}  familyType={selectedType} setQuizid={setQuizid}/>
+          <QuestionLayout
+            handleStep={handleStep}
+            name={name}
+            familyType={selectedType}
+            setQuizid={setQuizid}
+          />
         </Suspense>
       </Funnel.Steps>
       <Funnel.Steps name="완료">
-      <TestCompletedLayout 
-         nickname={name} 
-         quizid={quizid!} 
-       />      </Funnel.Steps>
+        <TestCompletedLayout nickname={name} quizid={quizid!} />{' '}
+      </Funnel.Steps>
     </Funnel>
   );
 }


### PR DESCRIPTION
# 🔢 이슈 번호

- #OMF-83

## ⚙ 작업 사항
- 이미지 업로드 api를 분리하여 답변 제출하기
- 채점 페이지에서 자식 카카오 닉네임과 애칭 정보 가져오기 
- 답변 조회 시 이미지 가져오기 

## 📷 스크린샷
<img width="200" alt="스크린샷 2025-01-06 01 26 38" src="https://github.com/user-attachments/assets/bbea49c9-a7fa-4ea7-bed3-ecdf23d302c4" />
<img width="200" alt="스크린샷 2025-01-06 01 26 49" src="https://github.com/user-attachments/assets/a889dd01-ffba-485a-baa4-43f71addb435" />
<img width="200" alt="스크린샷 2025-01-06 22 06 54" src="https://github.com/user-attachments/assets/cfacb658-b867-4fe9-a967-30bb21d451ea" />
