### PR TITLE
가이드 페이지의 CTA 버튼 조건부 렌더링

### DIFF
--- a/src/container/check-score/emptyScore.tsx
+++ b/src/container/check-score/emptyScore.tsx
@@ -1,6 +1,5 @@
 import $ from './emptyScore.module.scss';
 import classNames from 'classnames';
-import AppBar from '@/components/common/AppBar';
 import { Body3, Title2, Button2 } from '@/components/common/Typography';
 import { useNavigate } from 'react-router-dom';
 import blank from '@/assets/svg/Blank.svg';
@@ -10,7 +9,7 @@ export default function EmptyScoreLayout() {
   const navigate = useNavigate();
 
   const HowToStart = () => {
-    navigate('/guide');
+    navigate('/guide', { state: { from: 'emptyScore' } });
   }
 
   const startTest = () => {

--- a/src/container/guide/index.tsx
+++ b/src/container/guide/index.tsx
@@ -1,6 +1,6 @@
 import AppBar from '@/components/common/AppBar';
 import $ from './guide.module.scss';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Body2, Caption1, Title2, Title3 } from '@/components/common/Typography';
 import Guide1 from '@/assets/image/guide1.png';
 import Guide2 from '@/assets/image/guide2.png';
@@ -47,6 +47,9 @@ const guideArray = [
 
 export default function GuideLayout() {
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const isFromEmptyScore = location.state?.from === 'emptyScore';
 
   const onClickLeftButton = () => {
     navigate(-1);
@@ -55,6 +58,11 @@ export default function GuideLayout() {
   const onClickKakaoLoginButton = () => {
     window.location.href = kakaoLoginLink;
   };
+
+  const startTest = () => {
+    navigate('/test');
+  };
+  
   return (
     <>
       <AppBar leftRole="back" onClickLeftButton={onClickLeftButton} className={$.appbar} />
@@ -86,9 +94,13 @@ export default function GuideLayout() {
             </div>
           );
         })}
-        <Button icon={KakaoLogo} variant="kakaoLogin" onClick={onClickKakaoLoginButton}>
-          로그인하고 테스트 시작하기
-        </Button>
+       {isFromEmptyScore ? (
+          <Button variant='primary' onClick={startTest}>테스트 시작하기</Button>
+        ) : (
+          <Button icon={KakaoLogo} variant="kakaoLogin" onClick={onClickKakaoLoginButton}>
+            로그인하고 테스트 시작하기
+          </Button>
+        )}
       </div>
     </>
   );

--- a/src/container/login/index.tsx
+++ b/src/container/login/index.tsx
@@ -17,7 +17,7 @@ export default function LoginLayout() {
   };
 
   const handleTutorial = () => {
-    navigate('/guide');
+    navigate('/guide', { state: { from: 'login' } });
   };
 
   return (


### PR DESCRIPTION
# 🔢 이슈 번호
- #OMF-146

## ⚙ 작업 사항
- `useLocation`으로 가이드 페이지에서 이전 페이지(로그인/점수확인)에 따라 서로 다른 CTA 버튼을 보여주도록 수정함
  - 로그인 -> 로그인하고 테스트 시작하기
  - 빈 점수 페이지 -> 테스트 시작하기

## 📷 스크린샷
<img width="200" alt="스크린샷 2025-04-09 04 21 28" src="https://github.com/user-attachments/assets/5066e08c-ce8f-477e-aa54-d2de8d0b6225" />
<img width="200" alt="스크린샷 2025-04-09 04 21 14" src="https://github.com/user-attachments/assets/4972d77f-e6d6-4453-aa88-450fd70858b8" />
