### PR TITLE
이름 변경 컴포넌트 ui 구현

### DIFF
--- a/src/components/common/Card/ResultCard.tsx
+++ b/src/components/common/Card/ResultCard.tsx
@@ -1,7 +1,7 @@
-import Body3 from '../Typography/Body3';
 import Title2 from '../Typography/Title2';
 import classNames from 'classnames';
 import $ from './resultcard.module.scss';
+import { Body2 } from '../Typography';
 
 export interface ResultCardProps {
   score: number;
@@ -36,7 +36,7 @@ const ResultCard = ({ score, image, title, description, variant, isHas }: Result
       >
         <Title2>{title}</Title2>
         {variant === 'score' &&
-          (score === 80 ? <Title2>{description}</Title2> : <Body3>{description}</Body3>)}{' '}
+          (score === 80 ? <Title2>{description}</Title2> : <Body2>{description}</Body2>)}{' '}
       </div>
     </div>
   );

--- a/src/components/common/Card/resultcard.module.scss
+++ b/src/components/common/Card/resultcard.module.scss
@@ -42,6 +42,10 @@
 }
 
 .content {
+  color: $Gray500;
+  h2 {
+    margin-bottom: 8px;
+  }
   &.blur {
     @include blur;
   }

--- a/src/components/common/KakaoShareButton/index.tsx
+++ b/src/components/common/KakaoShareButton/index.tsx
@@ -1,7 +1,9 @@
-import Button from '../Button';
 import kakaoLogo from '@/assets/svg/KakaoLogo.svg';
 import { KAKAO_JS_KEY } from '@/constants/develop.constants';
 import { useEffect } from 'react';
+import { Button1 } from '../Typography';
+import classNames from 'classnames';
+import $ from './kakaoShareButton.module.scss';
 
 interface KakaoShareButttonProps {
   variant: 'grading' | 'test';
@@ -39,8 +41,9 @@ export default function KakaoShareButton({ variant, quizid, name }: KakaoShareBu
   };
 
   return (
-    <Button variant="kakaoLogin" icon={kakaoLogo} onClick={onClickShareButton}>
-      답안지 링크 공유
-    </Button>
+    <div className={classNames($.Container)} onClick={onClickShareButton}>
+      <img src={kakaoLogo} />
+      <Button1>답안지 링크 공유</Button1>
+    </div>
   );
 }

--- a/src/components/common/KakaoShareButton/index.tsx
+++ b/src/components/common/KakaoShareButton/index.tsx
@@ -40,7 +40,7 @@ export default function KakaoShareButton({ variant, quizid, name }: KakaoShareBu
 
   return (
     <Button variant="kakaoLogin" icon={kakaoLogo} onClick={onClickShareButton}>
-      카카오톡으로 공유하기
+      답안지 링크 공유
     </Button>
   );
 }

--- a/src/components/common/KakaoShareButton/kakaoShareButton.module.scss
+++ b/src/components/common/KakaoShareButton/kakaoShareButton.module.scss
@@ -1,0 +1,20 @@
+@use '@/colors' as *;
+@use '@/styles/mixin.scss' as *;
+
+.Container {
+  width: 100%;
+  height: 56px;
+  border-radius: 28px;
+  border: none;
+  cursor: pointer;
+  position: relative;
+  @include center;
+  flex-shrink: 0;
+  background-color: $Bi-kakao;
+  color: black;
+  img {
+    margin-right: 8px;
+    height: 17px;
+    width: 18px;
+  }
+}

--- a/src/components/common/Textarea/index.tsx
+++ b/src/components/common/Textarea/index.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react';
 import $ from '@/components/common/Textarea/textarea.module.scss';
 import X from '@/assets/svg/X.svg?react';
-import { Body3 } from '@/components/common/Typography';
+import { Body2, Body3 } from '@/components/common/Typography';
 
 interface TextareaProps {
   text: string;
@@ -18,6 +18,7 @@ interface TextareaProps {
   maxLength?: number;
   inputMode?: 'text' | 'numeric';
   showCounter?: boolean;
+  buttonType?: 'clear' | 'save';
   variant?: 'date';
   onKeyUp?: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
 }
@@ -28,6 +29,7 @@ export default function Textarea({
   maxLength,
   inputMode,
   showCounter,
+  buttonType,
   variant,
   onKeyUp,
 }: TextareaProps) {
@@ -62,7 +64,7 @@ export default function Textarea({
   };
 
   useEffect(() => {
-    if (text == '') {
+    if (text === '') {
       setIsTyping(false);
     } else {
       setIsTyping(true);
@@ -89,6 +91,43 @@ export default function Textarea({
       document.removeEventListener('touchstart', handleTextareaDivOutside);
     };
   }, []);
+  //X 버튼 또는 저장 버튼이 UI에 표시되어야 하는지 여부를 결정
+  const shouldShowButton = () => {
+    //글자수 표시 거나 날짜입력모드인 경우
+    if (showCounter || variant === 'date') return false;
+    //X버튼은 isTyping상태에 따라 표시됨!
+    if (buttonType === 'clear') {
+      return isTyping;
+    } else if (buttonType === 'save') {
+      return true;
+    }
+    return false;
+  };
+
+  const renderButton = () => {
+    if (!shouldShowButton()) return null;
+
+    if (buttonType === 'clear') {
+      return (
+        <div className={classNames($.textareaCloseWrapper)}>
+          <X className={classNames($.textareaClose)} onClick={handleClear} />
+        </div>
+      );
+    } else if (buttonType === 'save') {
+      return (
+        <div className={classNames($.textareaSaveWrapper, isTyping ? $.active : $.inactive)} onClick={handleSave} >
+          <Body2>저장</Body2>
+        </div>
+      );
+    }
+
+    return null;
+  };
+
+  // 저장 api 붙이기
+  const handleSave = () => {
+    console.log("저장 버튼 클릭함")
+  }
 
   return (
     <div className={classNames($.textareaContainer)}>
@@ -110,11 +149,7 @@ export default function Textarea({
           inputMode={inputMode}
           onKeyUp={onKeyUp}
         />
-        {isTyping && !showCounter && !variant && (
-          <div className={classNames($.textareaCloseWrapper)}>
-            <X className={classNames($.textareaClose)} onClick={handleClear} />
-          </div>
-        )}
+        {renderButton()}
       </div>
       {showCounter && (
         <div className={classNames($.counterWrapper)}>

--- a/src/components/common/Textarea/index.tsx
+++ b/src/components/common/Textarea/index.tsx
@@ -115,7 +115,17 @@ export default function Textarea({
       );
     } else if (buttonType === 'save') {
       return (
-        <div className={classNames($.textareaSaveWrapper, isTyping ? $.active : $.inactive)} onClick={handleSave} >
+        <div 
+          className={classNames(
+            $.textareaSaveWrapper,
+            isTyping ? $.active : $.inactive,
+            !isTyping && $.disabled 
+          )}
+          onClick={handleSave} 
+          style={{ 
+            cursor: isTyping ? 'pointer' : 'default' 
+          }}
+        >
           <Body2>저장</Body2>
         </div>
       );

--- a/src/components/common/Textarea/index.tsx
+++ b/src/components/common/Textarea/index.tsx
@@ -34,6 +34,9 @@ export default function Textarea({
   onKeyUp,
 }: TextareaProps) {
   const [isTyping, setIsTyping] = useState<boolean>(false);
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+  const [hasText, setHasText] = useState<boolean>(!!text);
+  
   //textarea을 focus하기 위해 useRef 사용(handleClear 실행 이후에도 포커스가 유지되도록)
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   //div 밖 영역 감지를 위해
@@ -64,11 +67,9 @@ export default function Textarea({
   };
 
   useEffect(() => {
-    if (text === '') {
-      setIsTyping(false);
-    } else {
-      setIsTyping(true);
-    }
+    const hasContent = text !== '';
+    setHasText(hasContent);
+    setIsTyping(hasContent);
   }, [text]);
 
   useEffect(() => {
@@ -78,7 +79,7 @@ export default function Textarea({
         !textareaWrapperRef.current.contains(event.target as Node) &&
         !(event.target as HTMLElement).closest('button') // 탭한 곳이 버튼인 경우는 제외
       ) {
-        setIsTyping(false);
+        setIsFocused(false);
         textareaRef.current?.blur();
       }
     };
@@ -91,13 +92,17 @@ export default function Textarea({
       document.removeEventListener('touchstart', handleTextareaDivOutside);
     };
   }, []);
-  //X 버튼 또는 저장 버튼이 UI에 표시되어야 하는지 여부를 결정
+
+  const handleFocus = () => {
+    setIsFocused(true);
+  };
+
   const shouldShowButton = () => {
     //글자수 표시 거나 날짜입력모드인 경우
     if (showCounter || variant === 'date') return false;
-    //X버튼은 isTyping상태에 따라 표시됨!
+    //X버튼은 텍스트가 있고 포커스가 있는 경우만 표시
     if (buttonType === 'clear') {
-      return isTyping;
+      return hasText && isFocused;
     } else if (buttonType === 'save') {
       return true;
     }
@@ -118,12 +123,12 @@ export default function Textarea({
         <div 
           className={classNames(
             $.textareaSaveWrapper,
-            isTyping ? $.active : $.inactive,
-            !isTyping && $.disabled 
+            hasText ? $.active : $.inactive,
+            !hasText && $.disabled 
           )}
           onClick={handleSave} 
           style={{ 
-            cursor: isTyping ? 'pointer' : 'default' 
+            cursor: hasText ? 'pointer' : 'default' 
           }}
         >
           <Body2>저장</Body2>
@@ -158,6 +163,7 @@ export default function Textarea({
           onChange={onChangeText}
           inputMode={inputMode}
           onKeyUp={onKeyUp}
+          onFocus={handleFocus}
         />
         {renderButton()}
       </div>

--- a/src/components/common/Textarea/textarea.module.scss
+++ b/src/components/common/Textarea/textarea.module.scss
@@ -1,5 +1,6 @@
 @use '@/colors' as *;
 @use '@/styles/mixin.scss' as *;
+@use '@/components/common/Typography/typography.module.scss' as *;
 
 .textareaContainer {
   width: 100%;
@@ -25,10 +26,7 @@
 .textarea {
   width: 100%;
   font-family: 'Pretendard';
-  font-size: 16px;
-  font-weight: 500;
-  line-height: 28px;
-  letter-spacing: 0%;
+  @include typography(0, 500, 16px, none, 28px);
   text-decoration: none;
   background-color: transparent;
   border: none;
@@ -36,7 +34,6 @@
   max-height: calc(100dvh - 573px);
   resize: none;
   overflow-y: auto;
-  color: $Gray500;
 
   &.date {
     text-align: center;

--- a/src/components/common/Textarea/textarea.module.scss
+++ b/src/components/common/Textarea/textarea.module.scss
@@ -82,6 +82,9 @@
       color: $Gray200;
     }
   }
+  &.disabled {
+    pointer-events: none; 
+}
 }
 
 .counterWrapper {

--- a/src/components/common/Textarea/textarea.module.scss
+++ b/src/components/common/Textarea/textarea.module.scss
@@ -2,151 +2,167 @@
 @use '@/styles/mixin.scss' as *;
 
 .textareaContainer {
-    width: 100%;
-    position: relative;
+  width: 100%;
+  position: relative;
 }
 
 .textareaWrapper {
-    width: 100%;
-    display: flex;
-    gap: 8px;
-    background-color: $Gray50;
-    border: none;
-    border-radius: 8px;
-    padding: 14px 16px;
-    overflow: hidden;
-    max-height: 100%; 
+  width: 100%;
+  display: flex;
+  gap: 8px;
+  background-color: $Gray50;
+  border: none;
+  border-radius: 8px;
+  padding: 14px 16px;
+  overflow: hidden;
+  max-height: 100%;
 
-    &.date {
-        padding: 8px;
-    }
+  &.date {
+    padding: 8px;
+  }
 }
 
 .textarea {
-    width: 100%;
-    font-family: 'Pretendard';
-    font-size: 16px;
-    font-weight: 500;
-    line-height: 28px;
-    letter-spacing: 0%;
-    text-decoration: none;
-    background-color: transparent;
-    border: none;
-    outline: none;
-    max-height: calc(100dvh - 573px); 
-    resize: none;
-    overflow-y: auto;
-    color: $Gray500;
+  width: 100%;
+  font-family: 'Pretendard';
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 28px;
+  letter-spacing: 0%;
+  text-decoration: none;
+  background-color: transparent;
+  border: none;
+  outline: none;
+  max-height: calc(100dvh - 573px);
+  resize: none;
+  overflow-y: auto;
+  color: $Gray500;
 
-    &.date {
-        text-align: center;
-    }
+  &.date {
+    text-align: center;
+  }
 
-    &::-webkit-scrollbar {
-        width: 3px; 
-    }
+  &::-webkit-scrollbar {
+    width: 3px;
+  }
 
-    &::-webkit-scrollbar-thumb {
-        background: $Gray100; 
-        border-radius: 14px; 
-    }
+  &::-webkit-scrollbar-thumb {
+    background: $Gray100;
+    border-radius: 14px;
+  }
 }
 
 .textareaClose {
-    width: 15px;
-    fill: $Gray200;
+  width: 15px;
+  fill: $Gray200;
 
-    &:active {
-      color: $Gray50;
-    }
+  &:active {
+    color: $Gray50;
+  }
 }
 
 .textareaCloseWrapper {
-    padding: 4.5px;
-    justify-content: center;
-    text-align: center;
-    display: flex;
+  padding: 4.5px;
+  justify-content: center;
+  text-align: center;
+  display: flex;
+}
+
+.textareaSaveWrapper {
+  white-space: nowrap;
+  @include center();
+  &.active {
+    p {
+      color: $main300;
+    }
+  }
+
+  &.inactive {
+    p {
+      color: $Gray200;
+    }
+  }
 }
 
 .counterWrapper {
-    position: absolute;
-    bottom: 3px;
-    right: 10px;
-    color: $Gray100;
+  position: absolute;
+  bottom: 3px;
+  right: 10px;
+  color: $Gray100;
 }
 
 .fieldWrapper {
-    width: 100%;
-    padding: 24px 16px;
-    justify-content: center;
-    text-align: start;
-    display: flex;
-    flex-direction: column;
-    border: none;
-    border-radius: 16px;
-    background-color: White;
-    box-shadow: inset 0 0 1px 0 #aeecff, 12px 12px 28px 0 rgba(0, 0, 0, 0.05);
+  width: 100%;
+  padding: 24px 16px;
+  justify-content: center;
+  text-align: start;
+  display: flex;
+  flex-direction: column;
+  border: none;
+  border-radius: 16px;
+  background-color: White;
+  box-shadow: inset 0 0 1px 0 #aeecff, 12px 12px 28px 0 rgba(0, 0, 0, 0.05);
 
-    .label {
-      margin-bottom: 8px;
-      color: $Gray300;
-    }
-    p {
-        color: $Gray300;
-    }
+  .label {
+    margin-bottom: 8px;
+    color: $Gray300;
+  }
+  p {
+    color: $Gray300;
+  }
 }
 
 .dateInputWrapper {
-    width: 100%;
-    padding: 16px;
-    justify-content: space-between;
-    gap: 16px;
-    text-align: start;
-    display: flex;
-    border: none;
-    border-radius: 16px;
-    background-color: White;
-    box-shadow: inset 0 0 1px 0 #aeecff, 12px 12px 28px 0 rgba(0, 0, 0, 0.05);
+  width: 100%;
+  padding: 16px;
+  justify-content: space-between;
+  gap: 16px;
+  text-align: start;
+  display: flex;
+  border: none;
+  border-radius: 16px;
+  background-color: White;
+  box-shadow: inset 0 0 1px 0 #aeecff, 12px 12px 28px 0 rgba(0, 0, 0, 0.05);
 
-    .label {
-        margin-bottom: 8px;
-    }
+  .label {
+    margin-bottom: 8px;
+  }
 
-    p {
-        color: $Gray300;
-    }
+  p {
+    color: $Gray300;
+  }
 }
 
 .inputWrapper {
-    display: flex;
-    @include center;
-    p {
-        margin-left: 8px;
-    }
-    
-    &.yearField {
-        flex: 1.4;
-    }
+  display: flex;
+  @include center;
+  p {
+    margin-left: 8px;
+  }
 
-    &.monthDayField {
-        flex: 1;
-    }
+  &.yearField {
+    flex: 1.4;
+  }
+
+  &.monthDayField {
+    flex: 1;
+  }
 }
 
 .namesWrapper {
-    margin-top: 24px;
-    color: $Gray300;
+  margin-top: 24px;
+  color: $Gray300;
 }
 
 .exampleButtonsWrapper {
-    margin-top: 8px;
-    display: flex;
+  margin-top: 8px;
+  display: flex;
 }
 
 .exampleButton {
-    padding: 4px 16px;
-    border-radius: 28px;
-    background-color: $main50;
-    color: $main300;
-    margin-right: 8px;
+  padding: 4px 16px;
+  border-radius: 28px;
+  background-color: $main50;
+  color: $main300;
+  margin-right: 8px;
 }

--- a/src/components/common/Textarea/textareaField.tsx
+++ b/src/components/common/Textarea/textareaField.tsx
@@ -13,9 +13,10 @@ interface TextareaFieldProps {
   inputMode?: 'text' | 'numeric';
   nameExamples?: 'mom' | 'dad' | 'others';
   showCounter?: boolean;
+  buttonType?: 'clear' | 'save';
 }
 
-function TextareaField({ label, text, setText, maxLength, inputMode, nameExamples, showCounter}: TextareaFieldProps) {
+function TextareaField({ label, text, setText, maxLength, inputMode, nameExamples, showCounter, buttonType}: TextareaFieldProps) {
 
   const currentExamples = nameExamples ? nicknameExamples[nameExamples] : [];
 
@@ -33,6 +34,7 @@ function TextareaField({ label, text, setText, maxLength, inputMode, nameExample
           maxLength={maxLength} 
           inputMode={inputMode}
           showCounter={showCounter}
+          buttonType={buttonType}
         />
         {nameExamples && (
           <div className={classNames($.namesWrapper)}>

--- a/src/components/common/Typography/index.tsx
+++ b/src/components/common/Typography/index.tsx
@@ -1,4 +1,4 @@
-import Body2 from './Body3';
+import Body2 from './Body2';
 import Body3 from './Body3';
 import Button1 from './Button1';
 import Button2 from './Button2';

--- a/src/components/common/Typography/typography.module.scss
+++ b/src/components/common/Typography/typography.module.scss
@@ -30,22 +30,22 @@
     @include typography(0, 600, 16px, none, 22px);
 }
 .button2 {
-    @include typography(0, 400, 14px, none, 20px);
+    @include typography(0, 500, 14px, none, 20px);
     &.underline {    
         border-bottom: 1px solid var(--underline-color, $Gray200);
     }
 } 
 .body1 {
-    @include typography(0, 400, 18px, none, 28px);
+    @include typography(0, 500, 18px, none, 28px);
 }
 .body2 {
-    @include typography(0, 400, 16px, none, 28px);
+    @include typography(0, 500, 16px, none, 28px);
     &.emphasis {    
         @include typography(0, 700, 16px, none, 28px);
     }
 }
 .body3 {
-    @include typography(0, 400, 14px, none, 26px);
+    @include typography(0, 500, 14px, none, 26px);
 }
 .caption1 {
     @include typography(0, 600, 12px, none, 22px);

--- a/src/container/check-score/checkScoreDetail.module.scss
+++ b/src/container/check-score/checkScoreDetail.module.scss
@@ -7,6 +7,7 @@
 
 .PaddingContainer {
   padding: 0 20px;
+  color: $Gray500;
 }
 
 .Container {
@@ -25,7 +26,8 @@
   flex-direction: column;
   text-align: center;
   margin-bottom: 56px;
-  p {
+
+  .contentDescription {
     color: $Gray300;
     margin-top: 24px;
     white-space: pre-wrap;

--- a/src/container/check-score/detail.tsx
+++ b/src/container/check-score/detail.tsx
@@ -43,14 +43,15 @@ export default function CheckScoreDetailLayout() {
             description={data.subtitle}
             variant="score"
           />
-          <Body2>{data.content}</Body2>
+          <div className={classNames($.contentDescription)}>
+            <Body2>{data.content}</Body2>
+          </div>
         </div>
 
         <div className={classNames($.AnimateCard)}>
           <div className={classNames($.PaddingContainer)}>
             <Title2>더 많은 카드를 수집해보세요!</Title2>
           </div>
-
           <AnimateCardSample />
         </div>
 

--- a/src/container/test/done/done.module.scss
+++ b/src/container/test/done/done.module.scss
@@ -1,23 +1,12 @@
 @use '@/styles/mixin.scss' as *;
 @use '@/colors' as *;
 
-%baseWrapper {
+.Wrapper {
   height: 100dvh;
   width: 100%;
   padding: 0 20px;
   display: flex;
   flex-direction: column;
-}
-
-.Wrapper {
-  @extend %baseWrapper;
-}
-
-.CompletedWrapper {
-  @extend %baseWrapper;
-  justify-content: space-between;
-  padding-top: 48px;
-  padding-bottom: 56px;
 }
 
 .Container {
@@ -35,6 +24,7 @@
 .exampleWrapper {
   background-color: $Gray000;
   padding: 24px 18px;
+  margin-top: 48px;
   margin-bottom: 32px;
   width: 100%;
   height: 378px;
@@ -77,6 +67,14 @@
 .ButtonContainer {
   width: 100%;
   display: flex;
-  flex-direction: column;
-  gap: 12px;
+  gap: 8px;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+.ButtonContainer > :first-child {
+  flex: 2.3;
+}
+
+.ButtonContainer > :last-child {
+  flex: 1;
 }

--- a/src/container/test/done/done.module.scss
+++ b/src/container/test/done/done.module.scss
@@ -1,20 +1,76 @@
 @use '@/styles/mixin.scss' as *;
+@use '@/colors' as *;
 
-.Wrapper {
+%baseWrapper {
+  height: 100dvh;
+  width: 100%;
   padding: 0 20px;
-  @include center;
+  display: flex;
   flex-direction: column;
 }
 
+.Wrapper {
+  @extend %baseWrapper;
+}
+
+.CompletedWrapper {
+  @extend %baseWrapper;
+  justify-content: space-between;
+  padding-top: 48px;
+  padding-bottom: 56px;
+}
+
 .Container {
+  flex: 1;
+  @include center();
+  flex-direction: column;
   text-align: center;
+  color: $Gray500;
+
   img {
-    margin-top: 80px;
     margin-bottom: 16px;
   }
+}
 
-  h2 {
+.exampleWrapper {
+  background-color: $Gray000;
+  padding: 24px 18px;
+  margin-bottom: 32px;
+  width: 100%;
+  height: 378px;
+  border-radius: 12px;
+  box-shadow: inset 0 0 4px 0 #ecfaff;
+}
+
+.exampleText {
+  background-color: $Bi-Bg-Blue;
+  border-radius: 12px;
+  height: 174px;
+  @include center();
+  flex-direction: column;
+
+  text-align: center;
+
+  .BlueTitleText {
     margin-bottom: 8px;
+  }
+  .TitleText {
+    color: $Gray400;
+  }
+}
+
+.exampleDescription {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 24px;
+  text-align: left;
+  .nicknameText {
+    color: $Gray500;
+  }
+
+  p {
+    color: $Gray300;
   }
 }
 
@@ -23,5 +79,4 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  margin: 48px 0;
 }

--- a/src/container/test/done/index.tsx
+++ b/src/container/test/done/index.tsx
@@ -80,52 +80,48 @@ function TestCompletedLayout({ nickname, quizid }: TestCompletedProps) {
       )}
 
       {step === 3 && (
-        <>
-          <div className={classNames($.CompletedWrapper)}>
-            <div className={classNames($.exampleContainer)}>
-              <div className={classNames($.exampleWrapper)}>
-                <div className={classNames($.exampleText)}>
-                  <div className={classNames($.BlueTitleText)}>
-                    <BlueTitleText size="lg">
-                      <Caption1>가정의 달 이벤트</Caption1>
-                    </BlueTitleText>
-                  </div>
-                  <div className={classNames($.TitleText)}>
-                    <Title1>
-                      {nameInput || names.kakao_nickname}이/가 직접 푼
-                      <br />
-                      {names.nickname} 10문 10답
-                    </Title1>
-                  </div>
-                </div>
-                <div className={classNames($.exampleDescription)}>
-                  <div className={classNames($.nicknameText)}>
-                    <Title3>{names.nickname}가 처음 보실 화면이에요.</Title3>
-                  </div>
-
-                  <Body2>내 이름을 바꾸고 싶다면 아래에 입력해주세요.</Body2>
-                  <Textarea
-                    text={nameInput}
-                    setText={setNameInput}
-                    inputMode="text"
-                    buttonType="save"
-                  />
-                </div>
+        <div className={classNames($.Wrapper)}>
+          <div className={classNames($.exampleWrapper)}>
+            <div className={classNames($.exampleText)}>
+              <div className={classNames($.BlueTitleText)}>
+                <BlueTitleText size="lg">
+                  <Caption1>가정의 달 이벤트</Caption1>
+                </BlueTitleText>
               </div>
-
-              <div className={classNames($.ButtonContainer)}>
-                <KakaoShareButton variant="grading" quizid={quizid} />
-                <Button variant="secondary" onClick={handleCopy}>
-                  답안지 링크 복사
-                </Button>
+              <div className={classNames($.TitleText)}>
+                <Title1>
+                  {nameInput || names.kakao_nickname}의
+                  <br />
+                  {names.nickname} 10문 10답
+                </Title1>
               </div>
             </div>
+            <div className={classNames($.exampleDescription)}>
+              <div className={classNames($.nicknameText)}>
+                <Title3>{names.nickname}께서 처음 보실 화면이에요.</Title3>
+              </div>
 
-            <Button variant="primary" onClick={handleRetry}>
-              다른 가족 문제 풀기
+              <Body2>이름을 바꾸고 싶다면 아래에 적고 저장해주세요.</Body2>
+              <Textarea
+                text={nameInput}
+                setText={setNameInput}
+                inputMode="text"
+                buttonType="save"
+              />
+            </div>
+          </div>
+
+          <div className={classNames($.ButtonContainer)}>
+            <KakaoShareButton variant="grading" quizid={quizid} />
+            <Button variant="tertiary" onClick={handleCopy}>
+              링크 복사
             </Button>
           </div>
-        </>
+
+          <Button variant="primary" onClick={handleRetry}>
+            다른 가족 문제 풀기
+          </Button>
+        </div>
       )}
     </>
   );

--- a/src/container/test/done/index.tsx
+++ b/src/container/test/done/index.tsx
@@ -92,8 +92,7 @@ function TestCompletedLayout({ nickname, quizid }: TestCompletedProps) {
                   </div>
                   <div className={classNames($.TitleText)}>
                     <Title1>
-                      {/* {nameInput || names.kakao_nickname}이 직접 푼 */}
-                      {names.kakao_nickname}이 직접 푼
+                      {nameInput || names.kakao_nickname}이/가 직접 푼
                       <br />
                       {names.nickname} 10문 10답
                     </Title1>
@@ -108,9 +107,8 @@ function TestCompletedLayout({ nickname, quizid }: TestCompletedProps) {
                   <Textarea
                     text={nameInput}
                     setText={setNameInput}
-                    maxLength={6}
                     inputMode="text"
-                    showCounter={true}
+                    buttonType="save"
                   />
                 </div>
               </div>

--- a/src/container/test/done/index.tsx
+++ b/src/container/test/done/index.tsx
@@ -1,4 +1,4 @@
-import { Body2, Title2 } from '@/components/common/Typography';
+import { Body2, Caption1, Title1, Title2, Title3 } from '@/components/common/Typography';
 import $ from './done.module.scss';
 import classNames from 'classnames';
 import KakaoShareButton from '@/components/common/KakaoShareButton';
@@ -6,6 +6,10 @@ import Button from '@/components/common/Button';
 import { useNavigate } from 'react-router-dom';
 import { AnimateClap } from '@/components/common/TossFace';
 import { useToast } from '@/hooks/useToast';
+import { useState, useEffect } from 'react';
+import BlueTitleText from '@/components/common/Item/BlueTitleText';
+import { useGetUserNames } from '@/apis/queries/user';
+import Textarea from '@/components/common/Textarea';
 
 interface TestCompletedProps {
   nickname: string;
@@ -15,11 +19,30 @@ interface TestCompletedProps {
 function TestCompletedLayout({ nickname, quizid }: TestCompletedProps) {
   const navigate = useNavigate();
   const { addToasts } = useToast();
+  const [step, setStep] = useState(1);
+  const [nameInput, setNameInput] = useState('');
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const names = quizid ? useGetUserNames(quizid) : null;
+
+  useEffect(() => {
+    const timer1 = setTimeout(() => {
+      setStep(2);
+    }, 2500);
+
+    const timer2 = setTimeout(() => {
+      setStep(3);
+    }, 4000);
+
+    return () => {
+      clearTimeout(timer1);
+      clearTimeout(timer2);
+    };
+  }, []);
 
   //링크 복사
   const handleCopy = async () => {
-    const shareURL = `${window.location.origin}/grading/${quizid}`;    
+    const shareURL = `${window.location.origin}/grading/${quizid}`;
 
     try {
       await navigator.clipboard.writeText(shareURL);
@@ -29,36 +52,85 @@ function TestCompletedLayout({ nickname, quizid }: TestCompletedProps) {
     }
   };
 
-  //처음으로 돌아가기
-  const handleReset = () => {
-    navigate('/main');
+  //다른 가족 선택하기
+  const handleRetry = () => {
+    navigate('/test');
   };
 
   return (
-    <div className={classNames($.Wrapper)}>
-      <div className={classNames($.Container)}>
-        <img src={AnimateClap} alt="박수 이미지" />
+    <>
+      {step === 1 && (
+        <div className={classNames($.Wrapper)}>
+          <div className={classNames($.Container)}>
+            <img src={AnimateClap} alt="박수 이미지" />
+            <Title2>문제를 다 풀었어요!</Title2>
+          </div>
+        </div>
+      )}
 
-        <Title2>문제를 다 풀었어요!</Title2>
-        <Body2>
-          답안지를 {nickname}에게 보내서
-          <br /> 채점을 받아볼까요?
-        </Body2>
-      </div>
+      {step === 2 && (
+        <div className={classNames($.Wrapper)}>
+          <div className={classNames($.Container)}>
+            <Title2>
+              답안지를 {names.nickname}에게 보내서
+              <br /> 채점을 받아볼까요?
+            </Title2>
+          </div>
+        </div>
+      )}
 
-      <div className={classNames($.ButtonContainer)}>
-        <KakaoShareButton variant="grading" quizid={quizid}/>
-        <Button variant="secondary" onClick={handleCopy}>
-          링크 복사
-        </Button>
-      </div>
+      {step === 3 && (
+        <>
+          <div className={classNames($.CompletedWrapper)}>
+            <div className={classNames($.exampleContainer)}>
+              <div className={classNames($.exampleWrapper)}>
+                <div className={classNames($.exampleText)}>
+                  <div className={classNames($.BlueTitleText)}>
+                    <BlueTitleText size="lg">
+                      <Caption1>가정의 달 이벤트</Caption1>
+                    </BlueTitleText>
+                  </div>
+                  <div className={classNames($.TitleText)}>
+                    <Title1>
+                      {/* {nameInput || names.kakao_nickname}이 직접 푼 */}
+                      {names.kakao_nickname}이 직접 푼
+                      <br />
+                      {names.nickname} 10문 10답
+                    </Title1>
+                  </div>
+                </div>
+                <div className={classNames($.exampleDescription)}>
+                  <div className={classNames($.nicknameText)}>
+                    <Title3>{names.nickname}가 처음 보실 화면이에요.</Title3>
+                  </div>
 
-      <Button variant="primary" onClick={handleReset}>
-        처음으로 돌아가기
-      </Button>
-    </div>
+                  <Body2>내 이름을 바꾸고 싶다면 아래에 입력해주세요.</Body2>
+                  <Textarea
+                    text={nameInput}
+                    setText={setNameInput}
+                    maxLength={6}
+                    inputMode="text"
+                    showCounter={true}
+                  />
+                </div>
+              </div>
+
+              <div className={classNames($.ButtonContainer)}>
+                <KakaoShareButton variant="grading" quizid={quizid} />
+                <Button variant="secondary" onClick={handleCopy}>
+                  답안지 링크 복사
+                </Button>
+              </div>
+            </div>
+
+            <Button variant="primary" onClick={handleRetry}>
+              다른 가족 문제 풀기
+            </Button>
+          </div>
+        </>
+      )}
+    </>
   );
 }
 
 export default TestCompletedLayout;
-

--- a/src/container/test/question/index.tsx
+++ b/src/container/test/question/index.tsx
@@ -193,6 +193,7 @@ function QuestionLayout({ handleStep, name, familyType, setQuizid }: QuestionLay
               setText={setAnswer}
               label={data[currentIndex].content}
               inputMode="numeric"
+              buttonType="clear"
             />
           )}
           {/* 일반텍스트형 (4-10번) */}
@@ -202,6 +203,7 @@ function QuestionLayout({ handleStep, name, familyType, setQuizid }: QuestionLay
               setText={setAnswer}
               label={data[currentIndex].content}
               inputMode="text"
+              buttonType="clear"
             />
           )}
         </div>

--- a/src/container/test/selectType/index.tsx
+++ b/src/container/test/selectType/index.tsx
@@ -25,24 +25,26 @@ function SelectTypeLayout({ handleStep, setSelectedType }: SelectTypeLayoutProps
   return (
     <div className={classNames($.Wrapper)}>
       <AppBar leftRole="back" onClickLeftButton={onClickLeftButton} />
-      <div className={classNames($.TextWrapper)}>
-        <Title2>누구에 대해 알아볼까요?</Title2>
-        <Body2>
-          선택한 사람에 대해
-          <br />
-          간단한 퀴즈 10개를 풀어볼 거예요.
-        </Body2>
-      </div>
-      <div className={classNames($.ButtonWrapper)}>
-        <Button variant="primary" onClick={() => handleNavigate('mom')}>
-          어머니
-        </Button>
-        <Button variant="primary" onClick={() => handleNavigate('dad')}>
-          아버지
-        </Button>
-        <Button variant="primary" onClick={() => handleNavigate('others')}>
-          다른 가족
-        </Button>
+      <div className={classNames($.ContentWrapper)}>
+        <div className={classNames($.TextWrapper)}>
+          <Title2>누구에 대해 알아볼까요?</Title2>
+          <Body2>
+            선택한 사람에 대해
+            <br />
+            간단한 퀴즈 10개를 풀어볼 거예요.
+          </Body2>
+        </div>
+        <div className={classNames($.ButtonWrapper)}>
+          <Button variant="primary" onClick={() => handleNavigate('mom')}>
+            어머니
+          </Button>
+          <Button variant="primary" onClick={() => handleNavigate('dad')}>
+            아버지
+          </Button>
+          <Button variant="primary" onClick={() => handleNavigate('others')}>
+            다른 가족
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/container/test/selectType/selectType.module.scss
+++ b/src/container/test/selectType/selectType.module.scss
@@ -2,8 +2,17 @@
 @use '@/styles/mixin.scss' as *;
 
 .Wrapper {
-  height: 100%;
+  height: 100dvh;
   padding: 0 20px;
+}
+
+.ContentWrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding-top: 32px;
+  padding-bottom: 178px;
+  height: calc(100% - 48px);
 }
 
 .TextWrapper {
@@ -11,8 +20,6 @@
   justify-content: flex-start;
   flex-direction: column;
   gap: 14px;
-  margin-top: 32px;
-  margin-bottom: 210px;
 
   h2 {
     color: $Gray500;


### PR DESCRIPTION
# 🔢 이슈 번호
-#OMF-147

## ⚙ 작업 사항
- 타이머를 사용하여 단계적으로 화면을 전환하여 답안 제출 완료 페이지를 구현했습니다.
- textarea 컴포넌트에 `buttonType` 속성을 추가하여 'clear'(X 버튼)와 'save'(저장 버튼) 두 가지 옵션을 선택하게 했습니다.
- 텍스트 존재 여부(hasText)와 포커스 상태(isFocused)를 분리했습니다.
- 카카오링크공유 버튼 ui 변경으로 기존 Button 컴포넌트를 사용하지 않고, 변경된 디자인에 맞춰 수정하였습니다.
- 점수 확인 페이지와 typography에 잘못 적용된 스타일을 수정했습니다.

## 📷 스크린샷

https://github.com/user-attachments/assets/c2dcd1cf-674b-4c5d-8d10-3799f59b7083

