### PR TITLE
이름 제한글자수 초과시 말줄임 처리

### DIFF
--- a/src/components/common/KakaoShareButton/index.tsx
+++ b/src/components/common/KakaoShareButton/index.tsx
@@ -43,7 +43,7 @@ export default function KakaoShareButton({ variant, quizid, name }: KakaoShareBu
   return (
     <div className={classNames($.Container)} onClick={onClickShareButton}>
       <img src={kakaoLogo} />
-      <Button1>답안지 링크 공유</Button1>
+      <Button1>{variant === 'test' ? '테스트 공유하기' : '답안지 링크 공유'}</Button1>
     </div>
   );
 }

--- a/src/container/grading/complete/HasImage/hasImage.module.scss
+++ b/src/container/grading/complete/HasImage/hasImage.module.scss
@@ -3,6 +3,18 @@
 .Wrapper {
     @include center();
     height: 100dvh;
+    overflow-y: auto;
+}
+
+.step1Wrapper {
+    height: 100dvh;
+    display: flex;
+    padding-top: 40px;
+    flex-direction: column;
+    &::-webkit-scrollbar {
+        display: none;
+    }
+    overflow-y: auto;
 }
 
 .layout { 
@@ -35,4 +47,7 @@
         border-radius: 12px;
     }
 }
- 
+
+.buttonWrapper {
+    margin-bottom: 120px;
+}

--- a/src/container/grading/complete/HasImage/index.tsx
+++ b/src/container/grading/complete/HasImage/index.tsx
@@ -7,6 +7,7 @@ import sample from '@/assets/image/splash1.png';
 import ButtonLayout from '@/components/domain/grading/buttonLayout';
 import { useParams } from 'react-router-dom';
 import { useGetUserNames } from '@/apis/queries/user';
+import cutName from '@/utils/cutName';
 
 type HasImageProps = {
   handleStep: (step: string) => void;
@@ -34,7 +35,7 @@ export default function HasImage({ handleStep, imageUrl }: HasImageProps) {
         {step === 1 && (
           <div className={$.step2}>
             <Title2>
-              {names.kakao_nickname}이 수줍게 <br /> 간직하고 있는 나의 사진입니다.
+              {cutName(names.kakao_nickname)}이 수줍게 <br /> 간직하고 있는 나의 사진입니다.
             </Title2>
             <div className={$.text}>
               <Body2>

--- a/src/container/grading/complete/HasImage/index.tsx
+++ b/src/container/grading/complete/HasImage/index.tsx
@@ -15,9 +15,9 @@ type HasImageProps = {
 };
 
 export default function HasImage({ handleStep, imageUrl }: HasImageProps) {
-  const {quizid} = useParams();
+  const { quizid } = useParams();
   const names = useGetUserNames(Number(quizid));
-  
+
   const [step, setStep] = useState<number>(0);
 
   useEffect(() => {
@@ -29,26 +29,36 @@ export default function HasImage({ handleStep, imageUrl }: HasImageProps) {
   }, []);
 
   return (
-    <div className={$.Wrapper}>
-      <div className={$.layout}>
-        {step === 0 && <ClapComplete />}
-        {step === 1 && (
-          <div className={$.step2}>
-            <Title2>
-              {cutName(names.kakao_nickname)}이 수줍게 <br /> 간직하고 있는 나의 사진입니다.
-            </Title2>
-            <div className={$.text}>
-              <Body2>
-                혹시 아주 약간 아쉽다면 <br /> 함께 사진찍는 추억을 만들어보는건 어떨까요?
-              </Body2>
-            </div>
-            <div className={$.image}>
-            <img src={imageUrl || sample} alt="자식 업로드 이미지" /> 
-            </div>
-            <ButtonLayout />
+    <>
+      {step === 0 && (
+        <div className={$.Wrapper}>
+          <div className={$.layout}>
+            <ClapComplete />
           </div>
-        )}
-      </div>
-    </div>
+        </div>
+      )}
+      {step === 1 && (
+        <div className={$.step1Wrapper}>
+          <div className={$.layout}>
+            <div>
+              <Title2>
+                {cutName(names.kakao_nickname)}이 수줍게 <br /> 간직하고 있는 나의 사진입니다.
+              </Title2>
+              <div className={$.text}>
+                <Body2>
+                  혹시 아주 약간 아쉽다면 <br /> 함께 사진찍는 추억을 만들어보는건 어떨까요?
+                </Body2>
+              </div>
+              <div className={$.image}>
+                <img src={imageUrl || sample} alt="자식 업로드 이미지" />
+              </div>
+              <div className={$.buttonWrapper}>
+                <ButtonLayout />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/container/grading/complete/NoImage/index.tsx
+++ b/src/container/grading/complete/NoImage/index.tsx
@@ -4,6 +4,7 @@ import ButtonLayout from '@/components/domain/grading/buttonLayout';
 import ClapComplete from '@/components/domain/grading/clapComplete';
 import { useGetUserNames } from '@/apis/queries/user';
 import { useParams } from 'react-router-dom';
+import cutName from '@/utils/cutName';
 
 type CompleteLayoutProps = {
   handleStep: (step: string) => void;
@@ -19,7 +20,7 @@ export default function NoImage({ handleStep }: CompleteLayoutProps) {
         <ClapComplete />
         <div className={$.text}>
           <Body2>
-            채점 결과는 {names.kakao_nickname}님이 직접 확인할 수 있답니다.
+            채점 결과는 {cutName(names.kakao_nickname)}님이 직접 확인할 수 있답니다.
             <br /> 다른 사람이 생각하는 내가 궁금하다면?
           </Body2>
         </div>

--- a/src/container/grading/guide/index.tsx
+++ b/src/container/grading/guide/index.tsx
@@ -7,6 +7,7 @@ import Button from '@/components/common/Button';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useGetUserNames } from '@/apis/queries/user';
+import cutName from '@/utils/cutName';
 
 type GuideLayoutProps = {
   handleStep: (step: string) => void;
@@ -29,7 +30,7 @@ export default function GuideLayout({ handleStep }: GuideLayoutProps) {
     <div className={$.layout}>
       <AppBar leftRole="back" onClickLeftButton={onClickLeftButton} className={$.appBar} />
       <GradingCard
-        title={`아래는 ${names.kakao_nickname}이
+        title={`아래는 ${cutName(names.kakao_nickname)}이
          나에 대해 답한 내용입니다.`}
         cardImage={Call}
         cardNumber="연습문제"

--- a/src/container/grading/main/index.tsx
+++ b/src/container/grading/main/index.tsx
@@ -6,6 +6,7 @@ import Button from '@/components/common/Button';
 import BackgroundSVG from '@/components/common/Item/BackgroundSVG';
 import { useParams } from 'react-router-dom';
 import { useGetUserNames } from '@/apis/queries/user';
+import cutName from '@/utils/cutName';
 
 type MainLayoutProps = {
   handleStep: (step: string) => void;
@@ -27,12 +28,12 @@ export default function MainLayout({ handleStep }: MainLayoutProps) {
             <Caption1>가정의 달 이벤트</Caption1>
           </BlueTitleText>
           <Title1>
-            {names.kakao_nickname}이 직접 푼
+            {cutName(names.kakao_nickname)}이 직접 푼
             <br />
             {names.nickname} 10문 10답
           </Title1>
           <Body3>
-          {names.kakao_nickname}이 나에 대한 간단한 퀴즈 10개를 풀었어요.
+            {cutName(names.kakao_nickname)}이 나에 대한 간단한 퀴즈 10개를 풀었어요.
             <br />
             정답은 오로지 나만 알고 있답니다!
             <br />

--- a/src/container/test/done/index.tsx
+++ b/src/container/test/done/index.tsx
@@ -11,6 +11,7 @@ import BlueTitleText from '@/components/common/Item/BlueTitleText';
 import { useGetUserNames } from '@/apis/queries/user';
 import Textarea from '@/components/common/Textarea';
 import { useChangeNameMutation } from '@/apis/queries/answer';
+import cutName from '@/utils/cutName';
 
 interface TestCompletedProps {
   nickname: string;
@@ -28,8 +29,8 @@ function TestCompletedLayout({ nickname, quizid, handleStep }: TestCompletedProp
   const names = quizid ? useGetUserNames(quizid) : null;
   
   useEffect(() => {
-    if (names && names.kakao_nickname) {
-      setDisplayName(names.kakao_nickname);
+    if (names && cutName(names.kakao_nickname)) {
+      setDisplayName(cutName(names.kakao_nickname));
     }
   }, [names]);
 
@@ -123,7 +124,7 @@ function TestCompletedLayout({ nickname, quizid, handleStep }: TestCompletedProp
               </div>
               <div className={classNames($.TitleText)}>
                 <Title1>
-                  {displayName || names.kakao_nickname}의
+                  {cutName(displayName || names.kakao_nickname)}의
                   <br />
                   {names.nickname} 10문 10답
                 </Title1>

--- a/src/pages/splash/index.tsx
+++ b/src/pages/splash/index.tsx
@@ -13,11 +13,16 @@ export default function Splash() {
       if (data) {
         Storage.setItem('userId', data.memberId);
         Storage.setItem('nickname', data.nickname);
-        // navigate('/');
+      }
+      const accessToken = Storage.getItem('accessToken');
+      if (accessToken) {
+        navigate('/main');
+      } else {
+        navigate('/login');
       }
     }, 3000);
     return () => clearTimeout(timer);
-  }, [data]);
+  }, []);
 
   return <SplashLayout />;
 }

--- a/src/utils/cutName.ts
+++ b/src/utils/cutName.ts
@@ -1,0 +1,10 @@
+// 자식 이름이 7자 초과시 말줄임 함수
+export const cutNickname = (text: string, maxLength: number = 7): string => {
+    if (!text) return '';
+    
+    return text.length > maxLength
+      ? `${text.substring(0, maxLength)}...`
+      : text;
+  };
+  
+  export default cutNickname;


### PR DESCRIPTION
# 🔢 이슈 번호

- #OMF-147

## ⚙ 작업 사항
- 제한글자수 초과시 말줄임 처리를 하는 함수 구현 후 필요한 페이지에 적용했습니다.
- 부모 채점시 사진을 확인하는 페이지의 레이아웃을 수정해 스크롤이 되지 않던 문제를 해결했습니다. 
- 스플래시 화면에서 로컬스토리지에 액세스 토큰이 있으면 main 페이지로, 없으면 login 페이지로 이동하도록 했습니다.

## 📷 스크린샷
<img width="200" alt="스크린샷 2025-04-29 21 52 56" src="https://github.com/user-attachments/assets/3a896b65-844f-44c6-9722-1ca196a345e7" />
<img width="200" alt="스크린샷 2025-04-29 21 49 49" src="https://github.com/user-attachments/assets/a9c1b01a-6cc5-4aea-9a6c-ace71f497ba2" />
<img width="200" alt="스크린샷 2025-04-29 21 50 00" src="https://github.com/user-attachments/assets/f88f28c4-ba24-416e-a751-4cb1f6a864b2" />
<img width="200" alt="스크린샷 2025-04-29 23 26 27" src="https://github.com/user-attachments/assets/cd19a066-cbaa-4405-a0e6-a5a466d26c43" />
<img width="200" alt="스크린샷 2025-04-29 23 26 32" src="https://github.com/user-attachments/assets/3fc174a7-7db9-4b0d-afa5-c337bd56aa8d" />
