### PR TITLE
채점을 완료한 퀴즈아이디의 채점확인 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,13 @@ declare global {
 function App() {
   const { ToastComponent } = useToast();
   const elem = useRoutes(routes);
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: 0
+      }
+    }
+  });
 
   return (
     <div className={$.Wrapper}>

--- a/src/apis/api/score.ts
+++ b/src/apis/api/score.ts
@@ -1,6 +1,7 @@
 import { instance } from '../instance';
 import { ApiResponseFormat } from './api.types';
 import { ScoreDetailResponse, ScoreType } from './score.type';
+import { AnswerResponseData } from './test.types';
 
 // 채점 점수 리스트 조회
 export const getScoreList = () => {
@@ -10,4 +11,16 @@ export const getScoreList = () => {
 // 점수 상세 페이지 조회
 export const getScoreDetail = (quizid: number) => {
   return instance.get<ApiResponseFormat<ScoreDetailResponse>>(`/api/search/detail?quizid=${quizid}`);
+};
+
+// 퀴즈 채점 여부 조회
+export const getQuizCheckStatus = (quizid: number) => {
+  return instance.get<ApiResponseFormat<boolean>>(`/api/v1/quiz/check/${quizid}`);
+};
+
+
+// 채점한 답변 조회
+export const getQuizGradedAnswers = async (quizid: number) => {
+  const { data } = await instance.get(`/api/v1/quiz/check/answer/${quizid}`);
+  return data;
 };

--- a/src/apis/api/test.types.ts
+++ b/src/apis/api/test.types.ts
@@ -16,6 +16,7 @@ export interface QuestionResponseData {
   content: string | string[];
   icon: string;
   answer?: string;
+  isAnswer?: boolean;
 }
 
 // 답변 제출 타입

--- a/src/apis/queries/score.ts
+++ b/src/apis/queries/score.ts
@@ -1,6 +1,8 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { ScoreDetailType, ScoreType } from '../api/score.type';
-import { getScoreDetail, getScoreList } from '../api/score';
+import { getQuizCheckStatus, getQuizGradedAnswers, getScoreDetail, getScoreList } from '../api/score';
+import { AnswerResponseData, QuestionResponseData } from '../api/test.types';
+import { ApiResponseFormat } from '../api/api.types';
 
 // 채점 점수 리스트 조회
 export const useScoreList = () => {
@@ -27,4 +29,28 @@ export const useScoreDetail = (quizid: number) => {
   });
   
   return data;
+};
+
+
+// 퀴즈 채점 여부 조회
+export const useQuizCheckStatus = (quizid: number) => {
+  return useSuspenseQuery<boolean>({
+    queryKey: ['quizCheckStatus', quizid],
+    queryFn: async () => {
+      const response = await getQuizCheckStatus(quizid);
+      return response.data.data;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+   
+};
+
+// 퀴즈 채점 내용 조회
+export const useQuizGradedAnswers = (quizid: number) => {
+  return useSuspenseQuery({
+    queryKey: ['quizGradedAnswers', quizid],
+    queryFn: () => getQuizGradedAnswers(quizid),
+    staleTime: 5 * 60 * 1000, 
+  });
+   
 };

--- a/src/apis/queries/user.ts
+++ b/src/apis/queries/user.ts
@@ -11,7 +11,7 @@ export const useKakaoLoginQuery = () => {
     mutationFn: kakaoLogin,
     onSuccess: (data) => {
         setAuthToken(data.data.accessToken, data.data.refreshToken);
-        navigate('/');
+        navigate('/main');
     },
     onError: () => navigate('/login')
     });
@@ -21,7 +21,8 @@ export const useGetUserInfo = () => {
     return useQuery({
         queryKey: ['userInfo'],
         queryFn: getUserInfo,
-        select: (response) => response.data
+        select: (response) => response.data,
+        enabled: false
     })
 }
 

--- a/src/components/common/Card/GradingCard.tsx
+++ b/src/components/common/Card/GradingCard.tsx
@@ -18,7 +18,9 @@ interface GradingCardProps {
   setState: Dispatch<SetStateAction<(boolean | null)[]>>;
   index: number;
   canEdit: boolean;
+  mainRef: React.RefObject<HTMLDivElement>;
 }
+
 function GradingCard({
   cardNumber,
   title,
@@ -27,7 +29,8 @@ function GradingCard({
   state,
   setState,
   index,
-  canEdit
+  canEdit,
+  mainRef
 }: GradingCardProps) {
   const [correctState, setCorrectState] = useState<boolean | null>(state[index]);
 
@@ -52,7 +55,12 @@ function GradingCard({
         <Body2>{answer}</Body2>
       </div>
       <div className={classNames($.ScoreButton)}>
-        <ScoreButton state={correctState} setState={setCorrectState} canEdit={canEdit}/>
+        <ScoreButton 
+          state={correctState} 
+          setState={setCorrectState} 
+          canEdit={canEdit}
+          mainRef={mainRef}
+        />
       </div>
     </div>
   );

--- a/src/components/common/Card/GradingCard.tsx
+++ b/src/components/common/Card/GradingCard.tsx
@@ -17,6 +17,7 @@ interface GradingCardProps {
   state: (boolean | null)[];
   setState: Dispatch<SetStateAction<(boolean | null)[]>>;
   index: number;
+  canEdit: boolean;
 }
 function GradingCard({
   cardNumber,
@@ -26,6 +27,7 @@ function GradingCard({
   state,
   setState,
   index,
+  canEdit
 }: GradingCardProps) {
   const [correctState, setCorrectState] = useState<boolean | null>(state[index]);
 
@@ -50,7 +52,7 @@ function GradingCard({
         <Body2>{answer}</Body2>
       </div>
       <div className={classNames($.ScoreButton)}>
-        <ScoreButton state={correctState} setState={setCorrectState} />
+        <ScoreButton state={correctState} setState={setCorrectState} canEdit={canEdit}/>
       </div>
     </div>
   );

--- a/src/components/common/Item/ScoreButton.tsx
+++ b/src/components/common/Item/ScoreButton.tsx
@@ -9,11 +9,21 @@ interface ScoreButtonProps {
   state: boolean | null;
   setState: Dispatch<SetStateAction<boolean | null>>;
   canEdit: boolean;
+  mainRef: React.RefObject<HTMLDivElement>;
 }
 
-const ScoreButton = ({ state, setState, canEdit}: ScoreButtonProps) => {
+const ScoreButton = ({ state, setState, canEdit, mainRef }: ScoreButtonProps) => {
   const handleClick = (state: boolean) => {
-    if (canEdit) setState(state);
+    if (canEdit) {
+      setState(state);
+      
+      if (mainRef.current) {
+          mainRef.current?.scrollTo({
+            top: mainRef.current.scrollTop + 340,
+            behavior: 'smooth',
+          });
+      }
+    }
   };
 
   return (

--- a/src/components/common/Item/ScoreButton.tsx
+++ b/src/components/common/Item/ScoreButton.tsx
@@ -8,11 +8,12 @@ import CheckCircle from '@/assets/svg/CheckCircle.svg?react';
 interface ScoreButtonProps {
   state: boolean | null;
   setState: Dispatch<SetStateAction<boolean | null>>;
+  canEdit: boolean;
 }
 
-const ScoreButton = ({ state, setState }: ScoreButtonProps) => {
+const ScoreButton = ({ state, setState, canEdit}: ScoreButtonProps) => {
   const handleClick = (state: boolean) => {
-    setState(state);
+    if (canEdit) setState(state);
   };
 
   return (

--- a/src/container/grading/check/index.tsx
+++ b/src/container/grading/check/index.tsx
@@ -17,7 +17,6 @@ import Button from '@/components/common/Button';
 import { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from 'react';
 import {
   useGetChildAnswer,
-  useSubmitAnswerMutation,
   useSubmitGrading,
 } from '@/apis/queries/answer';
 import { useParams } from 'react-router-dom';
@@ -51,6 +50,7 @@ const emoje = {
 export default function CheckLayout({ handleStep, setHasImage, setImageUrl}: CheckLayoutProps) {
   const [answerList, setAnswerList] = useState<(boolean | null)[]>(Array(10).fill(null));
   const {quizid} = useParams();
+  const mainRef = useRef<HTMLDivElement | null>(null);
 
   const { answers, imageUrl } = useGetChildAnswer(Number(quizid));
   useEffect(() => {
@@ -60,8 +60,6 @@ export default function CheckLayout({ handleStep, setHasImage, setImageUrl}: Che
       console.log(imageUrl);
     }
   }, [imageUrl, setHasImage, setImageUrl]);
-
-  const mainRef = useRef<HTMLDivElement | null>(null);
 
   const onSuccessSubmitGrade = () => {
     console.log('채점 성공');
@@ -81,7 +79,6 @@ export default function CheckLayout({ handleStep, setHasImage, setImageUrl}: Che
     handleStep('가이드');
   };
 
-
   const onClickCompleteButton = () => {
     const apiResult = [...(answerList as boolean[])].map((item, index) => ({
       isCorrect: item,
@@ -98,17 +95,6 @@ export default function CheckLayout({ handleStep, setHasImage, setImageUrl}: Che
     const array = answerList as (boolean | null)[];
     return array.some((item) => item === null);
   }, [answerList]);
-
-  useEffect(() => {
-    if (mainRef.current) {
-      mainRef.current.scrollTo({
-        top: mainRef.current.scrollTop + 340,
-        behavior: 'smooth',
-      });
-    }
-  }, [answerList]);
-
-
 
   return (
     <div className={$.layout}>
@@ -127,6 +113,7 @@ export default function CheckLayout({ handleStep, setHasImage, setImageUrl}: Che
                 index={index}
                 key={item.id}
                 canEdit={true}
+                mainRef={mainRef}
               />
             );
           })}

--- a/src/container/grading/check/index.tsx
+++ b/src/container/grading/check/index.tsx
@@ -126,6 +126,7 @@ export default function CheckLayout({ handleStep, setHasImage, setImageUrl}: Che
                 setState={setAnswerList as Dispatch<SetStateAction<(boolean | null)[]>>}
                 index={index}
                 key={item.id}
+                canEdit={true}
               />
             );
           })}

--- a/src/container/grading/checked/checked.module.scss
+++ b/src/container/grading/checked/checked.module.scss
@@ -1,0 +1,36 @@
+@use '@/styles/mixin.scss' as *;
+@use '@/colors' as *;
+
+.layout {
+    height: 100dvh;
+    display: flex;
+    flex-direction: column;
+    padding: 0 20px;
+}
+
+.container{
+    &::-webkit-scrollbar {
+        display: none;
+    }
+    overflow-y: auto;
+    height: calc(100dvh - 48px);
+padding-bottom: 40px;
+}
+
+.textWrapper {
+    text-align: center;
+    h2{
+        color: $Gray500;
+        margin-top: 24px;
+    }
+    p{
+        color: $Gray300;
+        margin: 16px 0;
+    }
+}
+
+.AnswerList {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}

--- a/src/container/grading/checked/index.tsx
+++ b/src/container/grading/checked/index.tsx
@@ -1,0 +1,95 @@
+import AppBar from '@/components/common/AppBar';
+import GradingCard from '@/components/common/Card/GradingCard';
+import $ from './checked.module.scss';
+import {
+  Actor,
+  Angel,
+  Birth,
+  Call,
+  Food,
+  Hobby,
+  Memory,
+  Music,
+  Think,
+  Wish,
+} from '@/components/common/TossFace';
+import { Dispatch, SetStateAction, useMemo } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuizGradedAnswers } from '@/apis/queries/score';
+import { QuestionResponseData } from '@/apis/api/test.types';
+import { Body3, Title2 } from '@/components/common/Typography';
+
+type CheckLayoutProps = {
+  handleStep: (step: string) => void;
+  setHasImage: Dispatch<SetStateAction<boolean>>;
+  setImageUrl: Dispatch<SetStateAction<string>>;
+};
+
+export type AnswerCardType = {
+  id: number;
+  icon: string;
+  title: string;
+  answer: string;
+};
+
+const emoje = {
+  call: Call,
+  actor: Actor,
+  angel: Angel,
+  birth: Birth,
+  food: Food,
+  hobby: Hobby,
+  memory: Memory,
+  music: Music,
+  wish: Wish,
+  think: Think,
+};
+
+export default function CheckedLayout({ handleStep }: CheckLayoutProps) {
+  const { quizid } = useParams();
+  const { data: answers } = useQuizGradedAnswers(Number(quizid));
+  
+  const onClickLeftButton = () => {
+    handleStep('메인');
+  };
+
+  const answerList = useMemo(() => {
+    return answers.data.map((item: QuestionResponseData) => item.isAnswer);
+  }, [answers])
+
+  return (
+    <div className={$.layout}>
+      <AppBar leftRole="back" onClickLeftButton={onClickLeftButton} />
+      <div className={$.container}>
+        <div className={$.textWrapper}>
+          <Title2>이미 채점한 답안지예요!</Title2>
+          <Body3>
+            새로 채점을 할 순 없지만
+            <br />
+            어떻게 채점하셨는지 보여드릴게요.
+            <br />
+            한데 모여 답안지를 보면서 얘기나누면 더 좋을 것 같아요!
+          </Body3>
+        </div>
+          <div className={$.AnswerList}>
+            {answers &&
+              answers.data.slice(0, 10).map((item: QuestionResponseData, index: number) => {
+                return (
+                  <GradingCard
+                    title={item.title}
+                    cardImage={emoje[item.icon as keyof typeof emoje]}
+                    cardNumber={index + 1}
+                    answer={item.answer}
+                    state={answerList as (boolean | null)[]}
+                    setState={answerList as Dispatch<SetStateAction<(boolean | null)[]>>}
+                    index={index}
+                    key={item.id}
+                    canEdit={false}
+                  />
+                );
+              })}
+          </div>
+        </div>
+    </div>
+  );
+}

--- a/src/container/grading/guide/index.tsx
+++ b/src/container/grading/guide/index.tsx
@@ -39,6 +39,8 @@ export default function GuideLayout({ handleStep }: GuideLayoutProps) {
         state={sample}
         setState={setSample}
         index={0}
+        canEdit={true}
+
       />
       <div className={$.textWrapper}>
         <Body3>

--- a/src/container/grading/main/index.tsx
+++ b/src/container/grading/main/index.tsx
@@ -7,6 +7,8 @@ import BackgroundSVG from '@/components/common/Item/BackgroundSVG';
 import { useParams } from 'react-router-dom';
 import { useGetUserNames } from '@/apis/queries/user';
 import cutName from '@/utils/cutName';
+import { useQuizCheckStatus } from '@/apis/queries/score';
+import { useEffect } from 'react';
 
 type MainLayoutProps = {
   handleStep: (step: string) => void;
@@ -15,10 +17,16 @@ type MainLayoutProps = {
 export default function MainLayout({ handleStep }: MainLayoutProps) {
   const {quizid} = useParams();
   const names = useGetUserNames(Number(quizid));
-
-  const onClickNextStep = () => {
-    handleStep('가이드');
+  const {data: quizCheckStatus} = useQuizCheckStatus(Number(quizid));
+ 
+  const onClickNextStep = () => { 
+    if (quizCheckStatus) {
+        handleStep('채점완료');
+      return ;
+    }
+    handleStep('가이드'); 
   };
+
   return (
     <div className={classNames($.Wrapper)}>
       <div className={classNames($.Container)}>

--- a/src/pages/grading/index.tsx
+++ b/src/pages/grading/index.tsx
@@ -7,9 +7,10 @@ import GuideLayout from '@/container/grading/guide';
 import MainLayout from '@/container/grading/main';
 import { useFunnel } from '@/hooks/useFunnel';
 import { Suspense, useState } from 'react';
+import CheckedLayout from '@/container/grading/checked';
 
 export default function Grading() {
-  const step = ['메인', '가이드', '채점', '완료'];
+  const step = ['메인', '가이드', '채점', '채점완료', '완료'];
   const { FunnelComponent: Funnel, handleStep } = useFunnel(step, {});
   const [hasImage, setHasImage] = useState<boolean>(false);
   const [imageUrl, setImageUrl] = useState<string>('');
@@ -29,6 +30,15 @@ export default function Grading() {
       <Funnel.Steps name="채점">
         <Suspense fallback={<GradingSkeletonLayout />}>
           <CheckLayout
+            handleStep={handleStep}
+            setHasImage={setHasImage}
+            setImageUrl={setImageUrl}
+          />
+        </Suspense>
+      </Funnel.Steps>
+      <Funnel.Steps name="채점완료">
+        <Suspense fallback={<GradingSkeletonLayout />}>
+          <CheckedLayout
             handleStep={handleStep}
             setHasImage={setHasImage}
             setImageUrl={setImageUrl}

--- a/src/pages/splash/index.tsx
+++ b/src/pages/splash/index.tsx
@@ -5,24 +5,24 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 export default function Splash() {
-  const { data } = useGetUserInfo();
+  const { data, refetch } = useGetUserInfo();
   const navigate = useNavigate();
 
   useEffect(() => {
-    const timer = setTimeout(async () => {
-      if (data) {
-        Storage.setItem('userId', data.memberId);
-        Storage.setItem('nickname', data.nickname);
-      }
-      const accessToken = Storage.getItem('accessToken');
-      if (accessToken) {
-        navigate('/main');
-      } else {
-        navigate('/login');
-      }
+    const timer = setTimeout(() => {
+      refetch();
     }, 3000);
+
     return () => clearTimeout(timer);
   }, []);
+
+  useEffect(() => {
+    if (data) {
+      Storage.setItem('userId', data.memberId);
+      Storage.setItem('nickname', data.nickname);
+      navigate('/main');
+    }
+  }, [data]);
 
   return <SplashLayout />;
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -20,7 +20,7 @@ export const routes = [
     element: <Layout />,
     path: '/',
     children: [
-      { path: '', element: <Index /> },
+      { path: '', element: <Splash /> },
       { path: 'homepage', element: <HomePage /> },
       {
         path: 'check-score',


### PR DESCRIPTION
# 🔢 이슈 번호

- #OMF-151

## ⚙ 작업 사항
- 이미 채점을 완료한 퀴즈아이디의 채점확인 페이지 구현
  - 답안지 채점 여부 확인, 채점 내용 조회 api 연동
- 채점 시 ScoreButton을 클릭할 때 페이지가 스크롤되도록 수정

## 📷 스크린샷
<img width="367" alt="스크린샷 2025-05-02 15 28 58" src="https://github.com/user-attachments/assets/d95f25cf-6f90-4561-b62f-f6709045c25d" />
