### PR TITLE
HEIC->JPG 파일 변환, 이미지 용량 압축 로직 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tanstack/react-query-devtools": "^5.59.20",
     "axios": "^1.7.7",
     "classnames": "^2.5.1",
+    "heic2any": "^0.0.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",

--- a/src/apis/api/auth.ts
+++ b/src/apis/api/auth.ts
@@ -15,7 +15,7 @@ export const getUserInfo = async() => {
 }
 
 // 채점 페이지에서 카카오이름, 애칭 정보 가져오기
-export const getUserNames = async (quizid: number) => {
+export const getUserNames = async (quizid: string) => {
     const { data } = await instance.get(`/api/user`, {
         params: {
             quizid: quizid

--- a/src/apis/api/score.ts
+++ b/src/apis/api/score.ts
@@ -8,6 +8,6 @@ export const getScoreList = () => {
 };
 
 // 점수 상세 페이지 조회
-export const getScoreDetail = (quizid: number) => {
+export const getScoreDetail = (quizid: string) => {
   return instance.get<ApiResponseFormat<ScoreDetailResponse>>(`/api/search/detail?quizid=${quizid}`);
 };

--- a/src/apis/api/score.type.ts
+++ b/src/apis/api/score.type.ts
@@ -1,6 +1,6 @@
 // 채점 점수 리스트 타입
 export interface ScoreType {
-  id: number;
+  id: string; //quizid
   ischeck: boolean;
   name: string;
   score: string;
@@ -13,7 +13,7 @@ export interface ScoresResponse {
 
 // 채점 결과 상세 정보 타입
 export interface ScoreDetailType {
-    id: number;
+    id: string; //quizid
     score: number;
     icon: string;
     title: string;

--- a/src/apis/api/test.ts
+++ b/src/apis/api/test.ts
@@ -50,7 +50,7 @@ export const changeName = async (payload: ChangeNamePayload) => {
 };
 
 // 답변 조회
-export const getAnswer = async (quizid: number): Promise<ApiResponseFormat<AnswerResponseData>> => {
+export const getAnswer = async (quizid: string): Promise<ApiResponseFormat<AnswerResponseData>> => {
   const { data } = await instance.get('api/answer', {
     params: { quizid },
   });

--- a/src/apis/api/test.types.ts
+++ b/src/apis/api/test.types.ts
@@ -28,7 +28,7 @@ export interface SubmitAnswerPayload {
 // 답변 제출 타입
 export interface ChangeNamePayload {
   name: string;
-  quizid: number;
+  quizid: string;
 }
 
 // 자식 답변 호출 타입
@@ -39,7 +39,7 @@ export interface AnswerResponseData {
 
 export interface SubmitAnswerResponse {
   data: {
-    quizid: number;
+    quizid: string;
   };
 }
 
@@ -48,5 +48,5 @@ export type GradingPayloadType = {
     id: number;
     isCorrect: boolean;
   }[];
-  quizid: number;
+  quizid: string;
 };

--- a/src/apis/queries/answer.ts
+++ b/src/apis/queries/answer.ts
@@ -1,16 +1,10 @@
 import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { changeName, getAnswer, submitAnswer, submitGrade, uploadImage } from '../api/test';
-import { SubmitAnswerResponse } from '../api/test.types';
 
 // 자식 답변 제출
-export const useSubmitAnswerMutation = (
-  onSuccess: (data: SubmitAnswerResponse) => void,
-  onError: () => void
-) => {
+export const useSubmitAnswerMutation = () => {
   return useMutation({
     mutationFn: submitAnswer,
-    onSuccess,
-    onError,
   });
 };
 

--- a/src/apis/queries/answer.ts
+++ b/src/apis/queries/answer.ts
@@ -40,7 +40,7 @@ export const useChangeNameMutation = (onSuccess?: () => void, onError?: () => vo
 };
 
 //답변 조회
-export const useGetChildAnswer = (quizid: number) => {
+export const useGetChildAnswer = (quizid: string) => {
   const { data } = useSuspenseQuery({
     queryKey: ['answer', quizid],
     queryFn: () => getAnswer(quizid),

--- a/src/apis/queries/score.ts
+++ b/src/apis/queries/score.ts
@@ -16,7 +16,7 @@ export const useScoreList = () => {
 };
 
 // 채점 결과 상세 조회
-export const useScoreDetail = (quizid: number) => {
+export const useScoreDetail = (quizid: string) => {
   const { data } = useSuspenseQuery<ScoreDetailType>({
     queryKey: ['scoreDetail', quizid],
     queryFn: async () => {

--- a/src/apis/queries/user.ts
+++ b/src/apis/queries/user.ts
@@ -25,7 +25,7 @@ export const useGetUserInfo = () => {
     })
 }
 
-export const useGetUserNames = (quizid: number) => {
+export const useGetUserNames = (quizid: string) => {
     const { data } = useSuspenseQuery({
       queryKey: ['userNames', quizid],
       queryFn: () => getUserNames(quizid),

--- a/src/components/common/Card/AnswerListItem.tsx
+++ b/src/components/common/Card/AnswerListItem.tsx
@@ -3,12 +3,12 @@ import $ from './answerlistitem.module.scss';
 import { Body3, Button1 } from '../Typography';
 
 interface AnswerListItemProps {
-  id: number;
+  id: string;
   name: string;
   score: number;
   icon?: string;
   ischeck: boolean;
-  handleClick: (id: number) => void;
+  handleClick: (id: string) => void;
 }
 
 function AnswerListItem({

--- a/src/components/common/KakaoShareButton/index.tsx
+++ b/src/components/common/KakaoShareButton/index.tsx
@@ -7,7 +7,7 @@ import $ from './kakaoShareButton.module.scss';
 
 interface KakaoShareButttonProps {
   variant: 'grading' | 'test';
-  quizid?: number;
+  quizid?: string;
   name?: string;
 }
 

--- a/src/components/common/Spinner/index.tsx
+++ b/src/components/common/Spinner/index.tsx
@@ -1,12 +1,15 @@
-import { Angel } from '../TossFace';
 import { Body2 } from '../Typography';
 import $ from './spinner.module.scss';
 
-export default function Spinner() {
+interface SpinnerProps {
+  showDescription?: boolean;
+}
+
+export default function Spinner({ showDescription }: SpinnerProps) {
   return (
     <div className={$.container}>
       <div className={$.spinner} />
-      <Body2>페이지를 불러오고 있어요!</Body2>
+      {showDescription && <Body2>페이지를 불러오고 있어요!</Body2>}
     </div>
   );
 }

--- a/src/components/common/Spinner/spinner.module.scss
+++ b/src/components/common/Spinner/spinner.module.scss
@@ -21,6 +21,7 @@
     p {
         color: $Gray300;
     }
+    max-width: 430px;
   }
   
   .spinner {

--- a/src/container/check-score/detail.tsx
+++ b/src/container/check-score/detail.tsx
@@ -12,7 +12,7 @@ import { useScoreDetail } from '@/apis/queries/score';
 export default function CheckScoreDetailLayout() {
   const navigate = useNavigate();
   const { id } = useParams();
-  const data = useScoreDetail(Number(id));
+  const data = useScoreDetail(String(id)); //id == quizid
 
   const onBack = () => {
     navigate(-1);

--- a/src/container/check-score/index.tsx
+++ b/src/container/check-score/index.tsx
@@ -16,7 +16,7 @@ export default function CheckScoreLayout() {
     navigate(-1);
   };
 
-  const handleItemClick = (id: number) => {
+  const handleItemClick = (id: string) => {
     navigate(`/check-score/${id}`);
   };
 

--- a/src/container/grading/check/index.tsx
+++ b/src/container/grading/check/index.tsx
@@ -52,7 +52,7 @@ export default function CheckLayout({ handleStep, setHasImage, setImageUrl}: Che
   const [answerList, setAnswerList] = useState<(boolean | null)[]>(Array(10).fill(null));
   const {quizid} = useParams();
 
-  const { answers, imageUrl } = useGetChildAnswer(Number(quizid));
+  const { answers, imageUrl } = useGetChildAnswer(String(quizid));
   useEffect(() => {
     setHasImage(!!imageUrl);
     if (imageUrl) {
@@ -90,7 +90,7 @@ export default function CheckLayout({ handleStep, setHasImage, setImageUrl}: Che
     
     submitGrade({
       result: apiResult,
-      quizid: Number(quizid) 
+      quizid: String(quizid) 
     });
   };
 

--- a/src/container/grading/complete/HasImage/index.tsx
+++ b/src/container/grading/complete/HasImage/index.tsx
@@ -16,7 +16,7 @@ type HasImageProps = {
 
 export default function HasImage({ handleStep, imageUrl }: HasImageProps) {
   const { quizid } = useParams();
-  const names = useGetUserNames(Number(quizid));
+  const names = useGetUserNames(String(quizid));
 
   const [step, setStep] = useState<number>(0);
 

--- a/src/container/grading/complete/NoImage/index.tsx
+++ b/src/container/grading/complete/NoImage/index.tsx
@@ -12,7 +12,7 @@ type CompleteLayoutProps = {
 
 export default function NoImage({ handleStep }: CompleteLayoutProps) {
   const {quizid} = useParams();
-  const names = useGetUserNames(Number(quizid));
+  const names = useGetUserNames(String(quizid));
   
   return (
     <div className={$.Wrapper}>

--- a/src/container/grading/guide/index.tsx
+++ b/src/container/grading/guide/index.tsx
@@ -15,7 +15,7 @@ type GuideLayoutProps = {
 
 export default function GuideLayout({ handleStep }: GuideLayoutProps) {
   const {quizid} = useParams();
-  const names = useGetUserNames(Number(quizid));
+  const names = useGetUserNames(String(quizid));
 
   const [sample, setSample] = useState<(boolean | null)[]>([null]);
   const onClickLeftButton = () => {

--- a/src/container/grading/main/index.tsx
+++ b/src/container/grading/main/index.tsx
@@ -14,7 +14,7 @@ type MainLayoutProps = {
 
 export default function MainLayout({ handleStep }: MainLayoutProps) {
   const {quizid} = useParams();
-  const names = useGetUserNames(Number(quizid));
+  const names = useGetUserNames(String(quizid));
 
   const onClickNextStep = () => {
     handleStep('가이드');

--- a/src/container/test/bonus/bonus.module.scss
+++ b/src/container/test/bonus/bonus.module.scss
@@ -28,6 +28,15 @@
   background-size: contain;
   background-position: center;
   background-repeat: no-repeat;
+
+  &.processing {
+    cursor: default;
+    pointer-events: none;
+
+    &:hover {
+      background-color: $Gray75;
+    }
+  }
 }
 
 .textWrapper {
@@ -36,6 +45,9 @@
   left: 50%;
   transform: translate(-50%, -50%);
   width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .ButtonContainer {

--- a/src/container/test/bonus/index.tsx
+++ b/src/container/test/bonus/index.tsx
@@ -6,7 +6,6 @@ import { Body2, Caption1, Title2 } from '@/components/common/Typography';
 import Button from '@/components/common/Button';
 import Spinner from '@/components/common/Spinner';
 import { QuestionLayoutType } from '@/pages/test';
-import { useUploadImageMutation } from '@/apis/queries/answer';
 import { useToast } from '@/hooks/useToast';
 import { compressImage, isHeicFile, convertHeicToJpeg } from '@/utils/imageUtils';
 
@@ -31,7 +30,6 @@ export const BonusStage = ({
   );
   const [isProcessing, setIsProcessing] = useState<boolean>(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { mutateAsync: uploadImage } = useUploadImageMutation();
   const { addToasts } = useToast();
 
   const handleImageClick = () => {
@@ -73,14 +71,7 @@ export const BonusStage = ({
 
   const handleComplete = async () => {
     try {
-      let image;
-      if (selectedImage) {
-        const response = await uploadImage(selectedImage);
-        image = response.data;
-      }
-      // image가 없으면 image는 undefined인 상태로 onSubmit 호출
-      onSubmit(image);
-      handleStep('완료');
+      onSubmit();
     } catch (error) {
       console.error('업로드 실패:', error);
     }

--- a/src/container/test/bonus/index.tsx
+++ b/src/container/test/bonus/index.tsx
@@ -4,8 +4,11 @@ import $ from './bonus.module.scss';
 import BlueTitleText from '@/components/common/Item/BlueTitleText';
 import { Body2, Caption1, Title2 } from '@/components/common/Typography';
 import Button from '@/components/common/Button';
+import Spinner from '@/components/common/Spinner';
 import { QuestionLayoutType } from '@/pages/test';
 import { useUploadImageMutation } from '@/apis/queries/answer';
+import { useToast } from '@/hooks/useToast';
+import { compressImage, isHeicFile, convertHeicToJpeg } from '@/utils/imageUtils';
 
 interface BonusStageProps extends QuestionLayoutType {
   nickname: string;
@@ -18,26 +21,53 @@ interface BonusStageProps extends QuestionLayoutType {
 export const BonusStage = ({
   content,
   title,
-  nickname,
   handleStep,
   onSubmit,
   selectedImage,
   setSelectedImage,
 }: BonusStageProps) => {
-  const [previewUrl, setPreviewUrl] = useState<string | null>(selectedImage ? URL.createObjectURL(selectedImage) : null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(
+    selectedImage ? URL.createObjectURL(selectedImage) : null
+  );
+  const [isProcessing, setIsProcessing] = useState<boolean>(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { mutateAsync: uploadImage } = useUploadImageMutation();
+  const { addToasts } = useToast();
 
   const handleImageClick = () => {
-    fileInputRef.current?.click();
+    if (!isProcessing) {
+      fileInputRef.current?.click();
+    }
   };
 
-  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
-      const url = URL.createObjectURL(file!);
-      setPreviewUrl(url);
-      setSelectedImage(file!);
+      setIsProcessing(true);
+      setPreviewUrl(null);
+
+      try {
+        let finalFile = file;
+        if (isHeicFile(file)) {
+          finalFile = await convertHeicToJpeg(file);
+          console.log('HEIC 변환 완료');
+        }
+        const shouldCompress = finalFile.size > 1 * 1024 * 1024;
+        const processedFile = shouldCompress ? await compressImage(finalFile) : finalFile;
+
+        const url = URL.createObjectURL(processedFile);
+        setPreviewUrl(url);
+        setSelectedImage(processedFile);
+      } catch (error) {
+        console.error('이미지 처리 실패:', error);
+        addToasts('다른 이미지로 다시 시도해주세요.', { top: '598px' });
+        
+        const url = URL.createObjectURL(file);
+        setPreviewUrl(url);
+        setSelectedImage(file);
+      } finally {
+        setIsProcessing(false);
+      }
     }
   };
 
@@ -46,7 +76,7 @@ export const BonusStage = ({
       let image;
       if (selectedImage) {
         const response = await uploadImage(selectedImage);
-        image = response.data; 
+        image = response.data;
       }
       // image가 없으면 image는 undefined인 상태로 onSubmit 호출
       onSubmit(image);
@@ -66,32 +96,45 @@ export const BonusStage = ({
 
       <input
         type="file"
-        accept="image/*"
+        accept="image/*,.heic,.HEIC"
         ref={fileInputRef}
         onChange={handleImageChange}
         style={{ display: 'none' }}
       />
 
       <div
-        className={$.ImageContainer}
+        className={classNames($.ImageContainer, { [$.processing]: isProcessing })}
         onClick={handleImageClick}
         style={previewUrl ? { backgroundImage: `url(${previewUrl})` } : undefined}
       >
-        {!previewUrl && (
+        {!previewUrl && !isProcessing && (
           <div className={$.textWrapper}>
             <Body2>
               탭하여 업로드하기
               <br />
-              이미지만 업로드 가능
+              (이미지만 업로드 가능)
             </Body2>
+          </div>
+        )}
+        {isProcessing && (
+          <div className={$.textWrapper}>
+            <Spinner showDescription={false} />
           </div>
         )}
       </div>
       <div className={classNames($.ButtonContainer)}>
-        <Button variant="tertiary" onClick={handleComplete} disabled={!!selectedImage}>
+        <Button
+          variant="tertiary"
+          onClick={handleComplete}
+          disabled={!!selectedImage || isProcessing}
+        >
           사진이 없어요 ㅜ
         </Button>
-        <Button variant="secondary" onClick={handleComplete} disabled={!selectedImage}>
+        <Button
+          variant="secondary"
+          onClick={handleComplete}
+          disabled={!selectedImage || isProcessing}
+        >
           완료
         </Button>
       </div>

--- a/src/container/test/done/index.tsx
+++ b/src/container/test/done/index.tsx
@@ -15,7 +15,7 @@ import cutName from '@/utils/cutName';
 
 interface TestCompletedProps {
   nickname: string;
-  quizid: number;
+  quizid: string;
   handleStep?: (step: string) => void;
 }
 

--- a/src/container/test/question/index.tsx
+++ b/src/container/test/question/index.tsx
@@ -29,7 +29,7 @@ interface QuestionLayoutProps {
   handleStep: (step: string) => void;
   name: string;
   familyType: string;
-  setQuizid: (quizid: number) => void;
+  setQuizid: (quizid: string) => void;
 }
 
 const emoje = {

--- a/src/container/test/question/index.tsx
+++ b/src/container/test/question/index.tsx
@@ -57,15 +57,7 @@ function QuestionLayout({ handleStep, name, familyType, setQuizid }: QuestionLay
     scrollToPosition: 200,
   });
 
-  const successSubmitAnswer = (response: SubmitAnswerResponse) => {
-    const { quizid } = response.data;
-    handleStep('완료');
-    setQuizid(quizid);
-  };
-
-  const failSubmitAnswer = () => {};
-
-  const { mutate: submitAnswer } = useSubmitAnswerMutation(successSubmitAnswer, failSubmitAnswer);
+  const { mutate: submitAnswer } = useSubmitAnswerMutation();
 
   const disabled = useMemo(() => {
     if (data && data[currentIndex]) {
@@ -129,11 +121,21 @@ function QuestionLayout({ handleStep, name, familyType, setQuizid }: QuestionLay
       const imageResponse = await uploadImage(selectedImage);
       image = imageResponse.data;
     }
-    submitAnswer({
-      name,
-      answer: result,
-      image,
-    });
+    submitAnswer(
+      {
+        name,
+        answer: result,
+        image,
+      },
+      {
+        onSuccess: (response) => { 
+          const { quizid } = response.data;
+          setQuizid(quizid);
+          handleStep('완료');
+        },
+        onError: () => console.log('에러 발생'),
+      }
+    );
   };
 
   //답 입력 버튼

--- a/src/pages/test/index.tsx
+++ b/src/pages/test/index.tsx
@@ -19,7 +19,7 @@ function Test() {
   const steps = ['선택', '애칭', '질문', '완료'];
   const [selectedType, setSelectedType] = useState<PersonType>('mom');
   const [selectedImage, setSelectedImage] = useState<FormData | null>(null);
-  const [quizid, setQuizid] = useState<number>();
+  const [quizid, setQuizid] = useState<string>();
   const [name, setName] = useState<string>(''); //애칭
 
   const { FunnelComponent: Funnel, handleStep } = useFunnel(steps, {});

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -1,0 +1,101 @@
+import heic2any from 'heic2any';
+
+/**
+ * 이미지 압축 함수
+ */
+export const compressImage = (file: File, maxWidth: number = 800): Promise<File> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    
+    reader.onload = (event) => {
+      const img = new Image();
+      img.src = event.target?.result as string;
+      
+      img.onload = () => {
+        const canvas = document.createElement('canvas');
+        let width = img.width;
+        let height = img.height;
+
+        if (width > height) {
+          if (width > maxWidth) {
+            height *= maxWidth / width;
+            width = maxWidth;
+          }
+        } else {
+          if (height > maxWidth) {
+            width *= maxWidth / height;
+            height = maxWidth;
+          }
+        }
+
+        canvas.width = width;
+        canvas.height = height;
+
+        const ctx = canvas.getContext('2d');
+        ctx?.drawImage(img, 0, 0, width, height);
+
+        canvas.toBlob(
+          (blob) => {
+            if (blob) {
+              const compressedFile = new File([blob], file.name, {
+                type: 'image/jpeg',
+                lastModified: Date.now(),
+              });
+              resolve(compressedFile);
+            } else {
+              reject(new Error('압축 실패'));
+            }
+          },
+          'image/jpeg',
+          0.8
+        );
+      };
+      
+      img.onerror = () => reject(new Error('이미지 로드 실패'));
+    };
+    
+    reader.onerror = () => reject(new Error('파일 읽기 실패'));
+  });
+};
+
+/**
+ * HEIC 파일인지 확인하는 함수
+ */
+export const isHeicFile = (file: File): boolean => {
+  return (
+    file.type === 'image/heic' ||
+    file.type === 'image/heif' ||
+    file.name.toLowerCase().endsWith('.heic') ||
+    file.name.toLowerCase().endsWith('.heif')
+  );
+};
+
+/**
+ * HEIC 파일을 JPEG로 변환하는 함수
+ */
+export const convertHeicToJpeg = async (file: File): Promise<File> => {
+  try {
+    const convertedResult = await heic2any({
+      blob: file,
+      toType: 'image/jpeg',
+      quality: 0.8,
+    });
+
+    const convertedBlob = Array.isArray(convertedResult)
+      ? convertedResult[0]
+      : convertedResult;
+
+    return new File(
+      [convertedBlob], 
+      file.name.replace(/\.(heic|heif)$/i, '.jpg'), 
+      {
+        type: 'image/jpeg',
+        lastModified: Date.now(),
+      }
+    );
+  } catch (error) {
+    console.error('HEIC 변환 실패:', error);
+    throw error;
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1288,6 +1288,11 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+heic2any@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/heic2any/-/heic2any-0.0.4.tgz#eddb8e6fec53c8583a6e18b65069bb5e8d19028a"
+  integrity sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==
+
 ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"


### PR DESCRIPTION
# 🔢 이슈 번호
- #OMF-83

## ⚙ 작업 사항
- 서버의 퀴즈아이디 암복호화 작업에 따라, `quizid`와 점수 조회 응답값의 `id` 타입을 `number` -> `string`으로 변경
- 이미지 첨부 시 파일의 확장자가 `heic`나 `heif`이면 jpeg으로 변환 (heic2any 라이브러리 사용)
- 파일 크기가 1mb이상인 경우 이미지 압축
- 변환/압축 진행(`isProcessing`) 중인 경우, 완료 버튼을 disabled 상태로 유지

## 📷 스크린샷

https://github.com/user-attachments/assets/51d89024-a4b1-45fd-b3b1-fd48fada5568

<img width="200" alt="스크린샷 2025-05-04 20 25 33" src="https://github.com/user-attachments/assets/10928cf6-f9d0-4ab0-9983-b50c52e4a433" />

